### PR TITLE
feat(BalanceTeams): implement balance teams and fix the average item level calculation

### DIFF
--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -1,5 +1,5 @@
 #
-# Copyright (С) since 2019 Andrei Guluaev (Winfidonarleyan/Kargatum) https://github.com/Winfidonarleyan 
+# Copyright (С) since 2019 Andrei Guluaev (Winfidonarleyan/Kargatum) https://github.com/Winfidonarleyan
 # Licence MIT https://opensource.org/MIT
 #
 
@@ -10,14 +10,18 @@
 
 ###################################################################################################
 #   CFBG
-#   
+#
 #   CFBG.Enable
-#       Description: Enable mixed alliance and horde in one battleground 
+#       Description: Enable mixed alliance and horde in one battleground
 #       Default: 1
 #
 #   CFBG.Include.Avg.Ilvl.Enable
 #       Description: Enable check average item level for bg
 #       Default: 0
+#
+#   CFBG.BalancedTeams
+#       Description: Enable check average player level for bg
+#       Default: 1
 #
 #   CFBG.Players.Count.In.Group
 #       Description: Maximum players in party for enter queue
@@ -25,5 +29,6 @@
 #
 
 CFBG.Enable = 1
+CFBG.BalancedTeams = 1
 CFBG.Include.Avg.Ilvl.Enable = 0
 CFBG.Players.Count.In.Group = 3

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -50,31 +50,29 @@ uint32 CFBG::GetMaxPlayersCountInGroup()
 uint32 CFBG::GetBGTeamAverageItemLevel(Battleground* bg, TeamId team)
 {
     if (!bg)
+    {
         return 0;
+    }
 
-    uint32 PlayersCount = bg->GetPlayersCountByTeam(team);
-    if (!PlayersCount)
-        return 0;
-
-    uint32 Sum = 0;
-    uint32 Count = 0;
+    uint32 sum = 0;
+    uint32 count = 0;
 
     for (auto itr : bg->GetPlayers())
     {
         Player* player = itr.second;
-        if (!player || player->GetTeamId() != team)
+        if (!!player && player->GetTeamId() == team)
         {
-            continue;
+            sum += player->GetAverageItemLevel();
+            count++;
         }
-
-        Sum += player->GetAverageItemLevel();
-        Count++;
     }
 
-    if (!Count || !Sum)
+    if (!count || !sum)
+    {
         return 0;
+    }
 
-    return Sum / Count;
+    return sum / count;
 }
 
 uint32 CFBG::GetBGTeamSumPlayerLevel(Battleground* bg, TeamId team)
@@ -84,26 +82,18 @@ uint32 CFBG::GetBGTeamSumPlayerLevel(Battleground* bg, TeamId team)
         return 0;
     }
 
-    uint32 PlayersCount = bg->GetPlayersCountByTeam(team);
-    if (!PlayersCount)
-    {
-        return 0;
-    }
-
-    uint32 Sum = 0;
+    uint32 sum = 0;
 
     for (auto itr : bg->GetPlayers())
     {
         Player* player = itr.second;
-        if (!player || player->GetTeamId() != team)
+        if (!!player && player->GetTeamId() == team)
         {
-            continue;
+            sum += player->getLevel();
         }
-
-        Sum += player->getLevel();
     }
 
-    return Sum;
+    return sum;
 }
 
 TeamId CFBG::GetLowerTeamIdInBG(Battleground* bg)

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -70,13 +70,16 @@ public:
 
     bool IsEnableSystem();
     bool IsEnableAvgIlvl();
+    bool IsEnableBalancedTeams();
     uint32 GetMaxPlayersCountInGroup();
 
     uint32 GetBGTeamAverageItemLevel(Battleground* bg, TeamId team);
+    uint32 GetBGTeamSumPlayerLevel(Battleground* bg, TeamId team);
     uint32 GetAllPlayersCountInBG(Battleground* bg);
 
     TeamId GetLowerTeamIdInBG(Battleground* bg);
     TeamId GetLowerAvgIlvlTeamInBg(Battleground* bg);
+    TeamId GetLowerSumPlayerLvlTeamInBg(Battleground* bg);
 
     bool IsAvgIlvlTeamsInBgEqual(Battleground* bg);
     bool SendRealNameQuery(Player* player);
@@ -114,6 +117,7 @@ private:
     // For config
     bool _IsEnableSystem;
     bool _IsEnableAvgIlvl;
+    bool _IsEnableBalancedTeams;
     uint32 _MaxPlayersCountInGroup;
 
     void randomRaceMorph(uint8* race, uint32* morph, TeamId team, uint8 _class, uint8 gender);


### PR DESCRIPTION
I fixed the average item level calculation and implemented the feature (enabled by default now) BalanceTeams.

This feature chooses the next team of the plater that joins BG taking the team with the lower sum of players' levels.
If the players' levels of the teams are the same it calculates the avg item level.

close https://github.com/azerothcore/mod-cfbg/issues/27