### PR TITLE
feat(EvenTeams): improve balance checking players level and avg item level before enter battle

### DIFF
--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -85,7 +85,7 @@ public:
 
     TeamId GetLowerTeamIdInBG(Battleground* bg, Player* player);
     TeamId GetLowerAvgIlvlTeamInBg(Battleground* bg);
-    TeamId GetLowerSumPlayerLvlTeamInBg(Battleground* bg, Player* player);
+    TeamId SelectBgTeam(Battleground* bg, Player* player);
 
     bool IsAvgIlvlTeamsInBgEqual(Battleground* bg);
     bool SendRealNameQuery(Player* player);

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -75,14 +75,17 @@ public:
     bool IsEnableEvenTeams();
     uint32 EvenTeamsMaxPlayersThreshold();
     uint32 GetMaxPlayersCountInGroup();
+    uint32 averagePlayersLevelQueue;
+    uint32 averagePlayersItemLevelQueue;
+    uint32 joiningPlayers;
 
     uint32 GetBGTeamAverageItemLevel(Battleground* bg, TeamId team);
     uint32 GetBGTeamSumPlayerLevel(Battleground* bg, TeamId team);
     uint32 GetAllPlayersCountInBG(Battleground* bg);
 
-    TeamId GetLowerTeamIdInBG(Battleground* bg);
+    TeamId GetLowerTeamIdInBG(Battleground* bg, Player* player);
     TeamId GetLowerAvgIlvlTeamInBg(Battleground* bg);
-    TeamId GetLowerSumPlayerLvlTeamInBg(Battleground* bg);
+    TeamId GetLowerSumPlayerLvlTeamInBg(Battleground* bg, Player* player);
 
     bool IsAvgIlvlTeamsInBgEqual(Battleground* bg);
     bool SendRealNameQuery(Player* player);

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -30,7 +30,9 @@ public:
         uint32 PlayerCountInBG = sCFBG->GetAllPlayersCountInBG(bg);
 
         if (PlayerCountInBG)
-            teamid = sCFBG->GetLowerTeamIdInBG(bg);
+        {
+            teamid = sCFBG->GetLowerTeamIdInBG(bg, player);
+        }
 
         if (!group)
             sCFBG->ValidatePlayerForBG(bg, player, teamid);


### PR DESCRIPTION
This PR improves the balance of the teams calculating the average player level and (avg) item level of the joined queue.

If there are 2 players in the battleground 15 vs 19, and two other players join with CFBG.EvenTeams enabled, regardless when they enter the battle their team will be calculated based on the next players which are joining.

So, having 15 v 19, if two players with level 19 and 18 join the queue when they can enter to the battle the core now calculates if the first player who click on "Enter Battle" is stronger than the other or not, based on this the team will be chosen for him.