### PR TITLE
feat(CFBG/BalanceClass): consider the class of the joining players when balance the low level BG

### DIFF
--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -24,6 +24,11 @@
 #       Description: Enable check average player level for bg
 #       Default: 1
 #
+#   CFBG.BalancedTeams.LowLevelClass
+#       Description: Enable class balance for BGs 10-19
+#       Default: 0
+#                1 - (Enabled. It puts Hunters in the weaker team)
+#
 #   CFBG.Players.Count.In.Group
 #       Description: Maximum players in party for enter queue
 #       Default: 3
@@ -38,9 +43,11 @@
 #       Default: 5 - (Quantity of players per team after the EvenTeams rule will be ignored)
 #                0 - (No treshold)
 #
+#
 
 CFBG.Enable = 1
 CFBG.BalancedTeams = 1
+CFBG.BalancedTeams.LowLevelClass = 0
 CFBG.Include.Avg.Ilvl.Enable = 0
 CFBG.Players.Count.In.Group = 3
 CFBG.EvenTeams.Enabled = 0

--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -26,8 +26,8 @@
 #
 #   CFBG.BalancedTeams.Class.LowLevel
 #       Description: Enable class balance for BGs LowLevel
-#       Default: 1 - (Enabled. Balance the number of Hunters per team)
-#                0
+#       Default: 0
+#                1 - (Enabled. Balance the number of Hunters per team)
 #
 #   CFBG.BalancedTeams.Class.MinLevel
 #       Description: Define min level to use the LowLevelClass balance

--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -24,14 +24,18 @@
 #       Description: Enable check average player level for bg
 #       Default: 1
 #
-#   CFBG.BalancedTeams.LowLevel
-#       Description: Define level for LowLevelClass Balance conf
-#       Default: 19 - (Balance the number of Hunters, considering the players level 19 and 19-1)
-#
-#   CFBG.BalancedTeams.LowLevelClass
+#   CFBG.BalancedTeams.Class.LowLevel
 #       Description: Enable class balance for BGs LowLevel
-#       Default: 0
-#                1 - (Enabled. Balance the number of Hunters per team)
+#       Default: 1 - (Enabled. Balance the number of Hunters per team)
+#                0
+#
+#   CFBG.BalancedTeams.Class.MinLevel
+#       Description: Define min level to use the LowLevelClass balance
+#       Default: 10
+#
+#   CFBG.BalancedTeams.Class.MaxLevel
+#       Description: Define max level to use the LowLevelClass balance
+#       Default: 19
 #
 #   CFBG.Players.Count.In.Group
 #       Description: Maximum players in party for enter queue
@@ -47,15 +51,12 @@
 #       Default: 5 - (Quantity of players per team after the EvenTeams rule will be ignored)
 #                0 - (No treshold)
 #
-#   CFBG.ResetCooldowns
-#        Description: Reset all cooldowns when joining battleground.
-#        Default:     0  - (Disabled)
-#                     1  - (Enabled)
 
 CFBG.Enable = 1
 CFBG.BalancedTeams = 1
-CFBG.BalancedTeams.LowLevel = 19
-CFBG.BalancedTeams.LowLevelClass = 0
+CFBG.BalancedTeams.Class.LowLevel = 1
+CFBG.BalancedTeams.Class.MinLevel = 10
+CFBG.BalancedTeams.Class.MaxLevel = 19
 CFBG.Include.Avg.Ilvl.Enable = 0
 CFBG.Players.Count.In.Group = 3
 CFBG.EvenTeams.Enabled = 0

--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -54,7 +54,7 @@
 
 CFBG.Enable = 1
 CFBG.BalancedTeams = 1
-CFBG.BalancedTeams.Class.LowLevel = 1
+CFBG.BalancedTeams.Class.LowLevel = 0
 CFBG.BalancedTeams.Class.MinLevel = 10
 CFBG.BalancedTeams.Class.MaxLevel = 19
 CFBG.Include.Avg.Ilvl.Enable = 0

--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -24,10 +24,14 @@
 #       Description: Enable check average player level for bg
 #       Default: 1
 #
+#   CFBG.BalancedTeams.LowLevel
+#       Description: Define level for LowLevelClass Balance conf
+#       Default: 19 - (Balance the number of Hunters, considering the players level 19 and 19-1)
+#
 #   CFBG.BalancedTeams.LowLevelClass
-#       Description: Enable class balance for BGs 10-19
+#       Description: Enable class balance for BGs LowLevel
 #       Default: 0
-#                1 - (Enabled. It puts Hunters in the weaker team)
+#                1 - (Enabled. Balance the number of Hunters per team)
 #
 #   CFBG.Players.Count.In.Group
 #       Description: Maximum players in party for enter queue
@@ -47,6 +51,7 @@
 
 CFBG.Enable = 1
 CFBG.BalancedTeams = 1
+CFBG.BalancedTeams.LowLevel = 19
 CFBG.BalancedTeams.LowLevelClass = 0
 CFBG.Include.Avg.Ilvl.Enable = 0
 CFBG.Players.Count.In.Group = 3

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -162,7 +162,8 @@ TeamId CFBG::SelectBgTeam(Battleground* bg, Player *player)
     {
         if (joiningPlayers % 2 == 0)
         {
-            if (player) {
+            if (player)
+            {
                 bool balancedClass = false;
 
                 auto playerLevel = player->getLevel();

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -75,7 +75,7 @@ public:
     bool IsEnableSystem();
     bool IsEnableAvgIlvl();
     bool IsEnableBalancedTeams();
-    bool IsEnableLowLevelClassBalance();
+    bool IsEnableBalanceClassLowLevel();
     bool IsEnableEvenTeams();
     bool IsEnableResetCooldowns();
     uint32 EvenTeamsMaxPlayersThreshold();
@@ -126,7 +126,7 @@ private:
     bool _IsEnableSystem;
     bool _IsEnableAvgIlvl;
     bool _IsEnableBalancedTeams;
-    bool _IsEnableLowLevelClassBalance;
+    bool _IsEnableBalanceClassLowLevel;
     bool _IsEnableEvenTeams;
     bool _IsEnableResetCooldowns;
     uint32 _EvenTeamsMaxPlayersThreshold;
@@ -134,7 +134,8 @@ private:
     uint32 averagePlayersLevelQueue;
     uint32 averagePlayersItemLevelQueue;
     uint32 joiningPlayers;
-    uint32 LowLevelBalance;
+    uint8 balanceClassMinLevel;
+    uint8 balanceClassMaxLevel;
 
     void RandomRaceMorph(uint8* race, uint32* morph, TeamId team, uint8 _class, uint8 gender);
 

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -132,11 +132,13 @@ private:
     uint32 averagePlayersLevelQueue;
     uint32 averagePlayersItemLevelQueue;
     uint32 joiningPlayers;
+    uint32 LowLevelBalance;
 
     void RandomRaceMorph(uint8* race, uint32* morph, TeamId team, uint8 _class, uint8 gender);
 
     uint8 GetRandomRace(std::initializer_list<uint32> races);
     uint32 GetMorphFromRace(uint8 race, uint8 gender);
+    TeamId getTeamWithLowerClass(Battleground *bg, Classes c);
 };
 
 #define sCFBG CFBG::instance()

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -75,6 +75,7 @@ public:
     bool IsEnableSystem();
     bool IsEnableAvgIlvl();
     bool IsEnableBalancedTeams();
+    bool IsEnableLowLevelClassBalance();
     bool IsEnableEvenTeams();
     uint32 EvenTeamsMaxPlayersThreshold();
     uint32 GetMaxPlayersCountInGroup();
@@ -124,6 +125,7 @@ private:
     bool _IsEnableSystem;
     bool _IsEnableAvgIlvl;
     bool _IsEnableBalancedTeams;
+    bool _IsEnableLowLevelClassBalance;
     bool _IsEnableEvenTeams;
     uint32 _EvenTeamsMaxPlayersThreshold;
     uint32 _MaxPlayersCountInGroup;


### PR DESCRIPTION
tested scenario:

- conf **EvenTeams** and **Balance Low Level Class** enabled
- in BG we have two teams:
- - TEAM 1  **player1 hunter level 14**
- - TEAM 2 **player2 level 18**
- **player3** level 19 paladin with high item level join
- **player4** level 19 **hunter** with low item level join
- the **player4** will go to the TEAM2 with lower quantity of hunters
 