### PR TITLE
fix: only handle the Queue Announcements either by Core or CFBG, not both

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -778,7 +778,6 @@ void CFBG::UpdateForget(Player* player)
 std::unordered_map<ObjectGuid, uint32> BGSpamProtectionCFBG;
 void CFBG::SendMessageQueue(BattlegroundQueue* bgQueue, Battleground* bg, PvPDifficultyEntry const* bracketEntry, Player* leader)
 {
-
     BattlegroundBracketId bracketId = bracketEntry->GetBracketId();
 
     char const* bgName = bg->GetName();

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -776,10 +776,8 @@ void CFBG::UpdateForget(Player* player)
 }
 
 std::unordered_map<ObjectGuid, uint32> BGSpamProtectionCFBG;
-bool CFBG::SendMessageQueue(BattlegroundQueue* bgQueue, Battleground* bg, PvPDifficultyEntry const* bracketEntry, Player* leader)
+void CFBG::SendMessageQueue(BattlegroundQueue* bgQueue, Battleground* bg, PvPDifficultyEntry const* bracketEntry, Player* leader)
 {
-    if (!IsEnableSystem())
-        return false;
 
     BattlegroundBracketId bracketId = bracketEntry->GetBracketId();
 
@@ -803,7 +801,7 @@ bool CFBG::SendMessageQueue(BattlegroundQueue* bgQueue, Battleground* bg, PvPDif
         // Skip if spam time < 30 secs (default)
         if (sWorld->GetGameTime() - BGSpamProtectionCFBG[leader->GetGUID()] < sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_SPAM_DELAY))
         {
-            return false;
+            return;
         }
 
         // When limited, it announces only if there are at least CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_PLAYERS in queue
@@ -815,13 +813,11 @@ bool CFBG::SendMessageQueue(BattlegroundQueue* bgQueue, Battleground* bg, PvPDif
 
             if (bg->GetBgTypeID() == bgTypeToLimit && qTotal < sWorld->getIntConfig(CONFIG_BATTLEGROUND_QUEUE_ANNOUNCER_LIMIT_MIN_PLAYERS))
             {
-                return false;
+                return;
             }
         }
 
         BGSpamProtectionCFBG[leader->GetGUID()] = sWorld->GetGameTime();
         sWorld->SendWorldText(LANG_BG_QUEUE_ANNOUNCE_WORLD, bgName, q_min_level, q_max_level, qTotal, MinPlayers);
     }
-
-    return true;
 }

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -104,7 +104,7 @@ public:
     bool ShouldForgetBGPlayers(Player* player);
     void SetForgetInListPlayers(Player* player, bool value);
     void UpdateForget(Player* player);
-    bool SendMessageQueue(BattlegroundQueue* bgQueue, Battleground* bg, PvPDifficultyEntry const* bracketEntry, Player* leader);
+    void SendMessageQueue(BattlegroundQueue* bgQueue, Battleground* bg, PvPDifficultyEntry const* bracketEntry, Player* leader);
 
     bool FillPlayersToCFBGWithSpecific(BattlegroundQueue* bgqueue, Battleground* bg, const int32 aliFree, const int32 hordeFree, BattlegroundBracketId thisBracketId, BattlegroundQueue* specificQueue, BattlegroundBracketId specificBracketId);
     bool FillPlayersToCFBG(BattlegroundQueue* bgqueue, Battleground* bg, const int32 aliFree, const int32 hordeFree, BattlegroundBracketId bracket_id);

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -125,10 +125,15 @@ public:
 
     bool CanSendMessageBGQueue(BattlegroundQueue* queue, Player* leader, Battleground* bg, PvPDifficultyEntry const* bracketEntry) override
     {
-        if (!bg->isArena() && sCFBG->IsEnableSystem() && sCFBG->SendMessageQueue(queue, bg, bracketEntry, leader))
-            return false;
+        if (bg->isArena() || !sCFBG->IsEnableSystem())
+        {
+            // if it's arena OR the CFBG is disabled, let the core handle the announcement
+            return true;
+        }
 
-        return true;
+        // otherwise, let the CFBG module handle the announcement
+        sCFBG->SendMessageQueue(queue, bg, bracketEntry, leader);
+        return false;
     }
 };
 


### PR DESCRIPTION
- Closes #58

I believe the current system is wrong as it lets both the CFBG **and** the core handle announcements. Instead, it should be only one of them. This was resulting in bugs such as #58

Now I changed it to:

- only make the Core handle the queue announcements **IF** it is arena **OR** if the CFBG is disabled
- only make the CFBG handle the queue announcements otherwise

## Test performed:

- tested locally with 1 player and the bug #58 is gone
- tested both with`CFBG.Enable = 1` and `CFBG.Enable = 0`, both seems fine

## What needs to be tested:
- test BG queue announcer in general, possibly with more chars ( both with`CFBG.Enable = 1` and `CFBG.Enable = 0`)
- a quick check on arena queue announcements wouldn't be bad, so we make sure we don't break them ( both with`CFBG.Enable = 1` and `CFBG.Enable = 0`)
- check that there is no regression in the queue announcements, it would be nice a quick check the Limit feature recently added
- would be interesting to play with `Battleground.QueueAnnouncer.SpamProtection.Delay` too and see how it goes