### PR TITLE
fix(CFBG): Set proper hostile reactions towards Alterac Valley NPCs a…

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -595,7 +595,7 @@ void CFBG::ClearFakePlayer(Player* player)
     player->SetNativeDisplayId(_fakePlayerStore[player].RealNativeMorph);
     SetFactionForRace(player, _fakePlayerStore[player].RealRace);
 
-    // Clear forced factions. Rank doesn't matter here, not used when they are removed.
+    // Clear forced faction reactions. Rank doesn't matter here, not used when they are removed.
     player->GetReputationMgr().ApplyForceReaction(FACTION_AV_FROSTWOLF_CLAN, REP_FRIENDLY, false);
     player->GetReputationMgr().ApplyForceReaction(FACTION_AV_STORMPIKE_GUARD, REP_FRIENDLY, false);
 

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -16,6 +16,10 @@
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
 
+constexpr uint32 FactionFrostwolfClan  = 729;
+constexpr uint32 FactionStormpikeGuard = 730;
+constexpr uint32 MapAlteracValley = 30;
+
 CFBG* CFBG::instance()
 {
     static CFBG instance;
@@ -268,17 +272,17 @@ void CFBG::ValidatePlayerForBG(Battleground* bg, Player* player, TeamId teamId)
     bg->GetTeamStartLoc(teamId, x, y, z, o);
     player->TeleportTo(bg->GetMapId(), x, y, z, o);
 
-    if (bg->GetMapId() == MAP_ALTERAC_VALLEY)
+    if (bg->GetMapId() == MapAlteracValley)
     {
         if (teamId == TEAM_HORDE)
         {
-            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_FROSTWOLF_CLAN, REP_FRIENDLY, true);
-            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_STORMPIKE_GUARD, REP_HOSTILE, true);
+            player->GetReputationMgr().ApplyForceReaction(FactionFrostwolfClan, REP_FRIENDLY, true);
+            player->GetReputationMgr().ApplyForceReaction(FactionStormpikeGuard, REP_HOSTILE, true);
         }
         else
         {
-            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_FROSTWOLF_CLAN, REP_HOSTILE, true);
-            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_STORMPIKE_GUARD, REP_FRIENDLY, true);
+            player->GetReputationMgr().ApplyForceReaction(FactionFrostwolfClan, REP_HOSTILE, true);
+            player->GetReputationMgr().ApplyForceReaction(FactionStormpikeGuard, REP_FRIENDLY, true);
         }
 
         player->GetReputationMgr().SendForceReactions();
@@ -596,8 +600,8 @@ void CFBG::ClearFakePlayer(Player* player)
     SetFactionForRace(player, _fakePlayerStore[player].RealRace);
 
     // Clear forced faction reactions. Rank doesn't matter here, not used when they are removed.
-    player->GetReputationMgr().ApplyForceReaction(FACTION_AV_FROSTWOLF_CLAN, REP_FRIENDLY, false);
-    player->GetReputationMgr().ApplyForceReaction(FACTION_AV_STORMPIKE_GUARD, REP_FRIENDLY, false);
+    player->GetReputationMgr().ApplyForceReaction(FactionFrostwolfClan, REP_FRIENDLY, false);
+    player->GetReputationMgr().ApplyForceReaction(FactionStormpikeGuard, REP_FRIENDLY, false);
 
     _fakePlayerStore.erase(player);
 }

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -13,6 +13,7 @@
 #include "Language.h"
 #include "Log.h"
 #include "Opcodes.h"
+#include "ReputationMgr.h"
 #include "ScriptMgr.h"
 
 CFBG* CFBG::instance()
@@ -266,6 +267,22 @@ void CFBG::ValidatePlayerForBG(Battleground* bg, Player* player, TeamId teamId)
     float x, y, z, o;
     bg->GetTeamStartLoc(teamId, x, y, z, o);
     player->TeleportTo(bg->GetMapId(), x, y, z, o);
+
+    if (bg->GetMapId() == MAP_ALTERAC_VALLEY)
+    {
+        if (teamId == TEAM_HORDE)
+        {
+            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_FROSTWOLF_CLAN, REP_FRIENDLY, true);
+            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_STORMPIKE_GUARD, REP_HOSTILE, true);
+        }
+        else
+        {
+            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_FROSTWOLF_CLAN, REP_HOSTILE, true);
+            player->GetReputationMgr().ApplyForceReaction(FACTION_AV_STORMPIKE_GUARD, REP_FRIENDLY, true);
+        }
+
+        player->GetReputationMgr().SendForceReactions();
+    }
 }
 
 uint32 CFBG::GetAllPlayersCountInBG(Battleground* bg)
@@ -577,6 +594,10 @@ void CFBG::ClearFakePlayer(Player* player)
     player->SetDisplayId(_fakePlayerStore[player].RealMorph);
     player->SetNativeDisplayId(_fakePlayerStore[player].RealNativeMorph);
     SetFactionForRace(player, _fakePlayerStore[player].RealRace);
+
+    // Clear forced factions. Rank doesn't matter here, not used when they are removed.
+    player->GetReputationMgr().ApplyForceReaction(FACTION_AV_FROSTWOLF_CLAN, REP_FRIENDLY, false);
+    player->GetReputationMgr().ApplyForceReaction(FACTION_AV_STORMPIKE_GUARD, REP_FRIENDLY, false);
 
     _fakePlayerStore.erase(player);
 }

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -47,6 +47,14 @@ enum FakeMorphs
 
 };
 
+enum AVData
+{
+    MAP_ALTERAC_VALLEY     = 30,
+
+    FACTION_AV_FROSTWOLF_CLAN  = 729,
+    FACTION_AV_STORMPIKE_GUARD = 730,
+};
+
 struct FakePlayer
 {
     // Fake

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -47,14 +47,6 @@ enum FakeMorphs
 
 };
 
-enum AVData
-{
-    MAP_ALTERAC_VALLEY     = 30,
-
-    FACTION_AV_FROSTWOLF_CLAN  = 729,
-    FACTION_AV_STORMPIKE_GUARD = 730,
-};
-
 struct FakePlayer
 {
     // Fake


### PR DESCRIPTION
…ccording to player team

Closes https://github.com/azerothcore/mod-cfbg/issues/76

Correct faction-changed players being hostile to their own team npcs, also forces the opposite team NPCs to be hostile.

Tests performed:

https://user-images.githubusercontent.com/47818697/140624997-4fa6eb19-365d-4912-a4c0-a706f77bdc8e.mp4

- Leaving BG, relogging - effects are removed properly:

![Skärmbild 2021-11-06 183225](https://user-images.githubusercontent.com/47818697/140624670-c379c196-1753-429e-aede-49e9efa5e18c.jpg)


