### PR TITLE
Fix reputation gain in AV

### DIFF
--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -61,6 +61,12 @@ struct FakePlayer
     TeamId  RealTeamID;
 };
 
+enum Factions
+{
+    FACTION_FROSTWOLF_CLAN = 729,
+    FACTION_STORMPIKE_GUARD = 730
+};
+
 class CFBG
 {
 public:

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -243,12 +243,11 @@ public:
     {
         uint32 repGain = player->GetReputation(factionID);
         TeamId teamId = player->GetTeamId(true);
-        uint32 diff = 0;
 
         if ((factionID == FACTION_FROSTWOLF_CLAN && teamId == TEAM_ALLIANCE) ||
             (factionID == FACTION_STORMPIKE_GUARD && teamId == TEAM_HORDE))
         {
-            diff = standing - repGain;
+            uint32 diff = standing - repGain;
             player->GetReputationMgr().ModifyReputation(sFactionStore.LookupEntry(teamId == TEAM_ALLIANCE ? FACTION_STORMPIKE_GUARD : FACTION_FROSTWOLF_CLAN), diff);
             return false;
         }

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -9,6 +9,7 @@
 #include "GroupMgr.h"
 #include "Opcodes.h"
 #include "ScriptMgr.h"
+#include "ReputationMgr.h"
 
 // CFBG custom script
 class CFBG_BG : public BGScript
@@ -236,6 +237,25 @@ public:
 
         // to gm lang
         lang = LANG_UNIVERSAL;
+    }
+
+    bool OnReputationChange(Player* player, uint32 factionID, int32& standing, bool incremental) override
+    {
+        uint32 repGain = player->GetReputation(factionID);
+        TeamId teamId = player->GetTeamId(true);
+        uint32 diff = 0;
+
+        if ((factionID == FACTION_FROSTWOLF_CLAN && teamId == TEAM_ALLIANCE) ||
+            (factionID == FACTION_STORMPIKE_GUARD && teamId == TEAM_HORDE))
+        {
+
+            diff = standing - repGain;
+            LOG_ERROR("misc", "Faction {}, standing {}, rep {}, diff {}", factionID, standing, repGain, diff);
+            player->GetReputationMgr().ModifyReputation(sFactionStore.LookupEntry(teamId == TEAM_ALLIANCE ? FACTION_STORMPIKE_GUARD : FACTION_FROSTWOLF_CLAN), diff);
+            return false;
+        }
+
+        return true;
     }
 
 private:

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -239,7 +239,7 @@ public:
         lang = LANG_UNIVERSAL;
     }
 
-    bool OnReputationChange(Player* player, uint32 factionID, int32& standing, bool incremental) override
+    bool OnReputationChange(Player* player, uint32 factionID, int32& standing, bool /*incremental*/) override
     {
         uint32 repGain = player->GetReputation(factionID);
         TeamId teamId = player->GetTeamId(true);
@@ -248,9 +248,7 @@ public:
         if ((factionID == FACTION_FROSTWOLF_CLAN && teamId == TEAM_ALLIANCE) ||
             (factionID == FACTION_STORMPIKE_GUARD && teamId == TEAM_HORDE))
         {
-
             diff = standing - repGain;
-            LOG_ERROR("misc", "Faction {}, standing {}, rep {}, diff {}", factionID, standing, repGain, diff);
             player->GetReputationMgr().ModifyReputation(sFactionStore.LookupEntry(teamId == TEAM_ALLIANCE ? FACTION_STORMPIKE_GUARD : FACTION_FROSTWOLF_CLAN), diff);
             return false;
         }


### PR DESCRIPTION
Added OnReputationChange hook to avoid players to gain reputation with their opposite faction, and instead give them the exact amount on the right one.

Needs the linked PR in order to get tested.