### PR TITLE
fix: Add missing OnLogout hook

### DIFF
--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -105,6 +105,7 @@ class CFBG_Player : public PlayerScript
 public:
     CFBG_Player() : PlayerScript("CFBG_Player", {
         PLAYERHOOK_ON_LOGIN,
+        PLAYERHOOK_ON_LOGOUT,
         PLAYERHOOK_CAN_JOIN_IN_BATTLEGROUND_QUEUE,
         PLAYERHOOK_ON_BEFORE_UPDATE,
         PLAYERHOOK_ON_BEFORE_SEND_CHAT_MESSAGE,


### PR DESCRIPTION
CFBG_Player was missing PLAYERHOOK_ON_LOGOUT in its constructor, making OnPlayerLogout dead code. Added the hook so fake races are correctly cleared on logout.

In OnBattlefieldPlayerJoinWar: removed a stale debug LOG_ERROR and updated the handler comment to reflect the core fix — the invite is now erased using GetTeamId(true) so no stale timer remains after the cross-faction team assignment.