### PR TITLE
fix(WG): migrate core containers after crossfaction team change

### DIFF
--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -256,7 +256,15 @@ public:
             assignedTeam = TEAM_ALLIANCE;
 
         if (assignedTeam != realTeam)
+        {
             sCFBG->PrepareFakeTeamForBF(player, assignedTeam);
+
+            // The player may have been queued or invited under their original
+            // team before entering the zone.  Now that the effective team has
+            // changed, move those entries so the core finds them under the
+            // correct bucket for all subsequent operations.
+            bf->MigratePlayerContainers(player->GetGUID(), realTeam, assignedTeam);
+        }
 
         // The player is NOT added to wgWarPlayers here; they are only added
         // once they actually accept the war invitation (OnBattlefieldPlayerJoinWar).
@@ -296,7 +304,10 @@ public:
             assignedTeam = TEAM_ALLIANCE;
 
         if (assignedTeam != realTeam)
+        {
             sCFBG->PrepareFakeTeamForBF(player, assignedTeam);
+            bf->MigratePlayerContainers(player->GetGUID(), realTeam, assignedTeam);
+        }
     }
 
     void OnBattlefieldPlayerJoinWar(Battlefield* bf, Player* player) override


### PR DESCRIPTION
## Summary
- After `PrepareFakeTeamForBF` changes a player's effective team, call `Battlefield::MigratePlayerContainers` to move pre-existing queue/invite/kick entries from the original team bucket to the new one
- Applied in both `OnBattlefieldPlayerEnterZone` (portal entry during war) and `OnBattlefieldBeforeInvitePlayerToWar` (pre-war zone players at battle start)
- Without this, players who queued or were invited under their real team before the crossfaction swap had orphaned entries causing double invites, missed cleanups, and incorrect kicks

## Dependencies
- Requires azerothcore/azerothcore-wotlk#25168 (adds `MigratePlayerContainers` + core stale-entry fixes)

## Test plan
- [ ] Queue for WG from outside the zone, enter via portal after crossfaction assigns opposite team — verify single invite, no kick
- [ ] Be in WG zone before battle starts, get assigned opposite team at battle start — verify invite lands under correct team
- [ ] Accept war invite after crossfaction swap — verify player stays in battle with no stale entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)