### PR TITLE
fix(WG): Restore fake faction immediately when war ends

### DIFF
--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -7,6 +7,7 @@
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
 #include "Group.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
@@ -215,7 +216,8 @@ public:
     CFBG_Battlefield() : BattlefieldScript("CFBG_Battlefield", {
         BATTLEFIELDHOOK_ON_PLAYER_JOIN_WAR,
         BATTLEFIELDHOOK_ON_PLAYER_LEAVE_WAR,
-        BATTLEFIELDHOOK_ON_PLAYER_LEAVE_ZONE
+        BATTLEFIELDHOOK_ON_PLAYER_LEAVE_ZONE,
+        BATTLEFIELDHOOK_ON_WAR_END
     }) {}
 
     void OnBattlefieldPlayerJoinWar(Battlefield* bf, Player* player) override
@@ -278,6 +280,30 @@ public:
         // player's real race/faction.
         if (sCFBG->IsPlayerFake(player))
             sCFBG->ClearFakePlayer(player);
+    }
+
+    void OnBattlefieldWarEnd(Battlefield* bf, bool /*endByTimer*/) override
+    {
+        if (!sCFBG->IsEnableSystem() || !sCFBG->IsEnableWGSystem())
+            return;
+
+        if (bf->GetTypeId() != BATTLEFIELD_WG)
+            return;
+
+        // When the war ends, the core clears PlayersInWar in bulk without
+        // firing per-player LeaveWar hooks.  Players staying in the WG zone
+        // never trigger LeaveZone either, so their fake faction would persist
+        // indefinitely.  Iterate our own tracking and restore each player now.
+        for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
+        {
+            for (ObjectGuid const& guid : _wgWarPlayers[team])
+            {
+                Player* player = ObjectAccessor::FindPlayer(guid);
+                if (player && sCFBG->IsPlayerFake(player))
+                    sCFBG->ClearFakePlayer(player);
+            }
+            _wgWarPlayers[team].clear();
+        }
     }
 
 private:


### PR DESCRIPTION
## Changes Proposed:

Fixes cross-faction players remaining disguised as the opposite faction after a Wintergrasp war ends, until they physically leave the zone or relog.

**Root cause:** When `Battlefield::EndBattle()` fires, `BattlefieldWG::OnBattleEnd()` clears `PlayersInWar` in bulk — `OnBattlefieldPlayerLeaveWar` never fires per-player. Players who stay in the WG zone after war ends never trigger `OnBattlefieldPlayerLeaveZone` either. The fake race/faction set by `SetFakeRaceAndMorphForBF` therefore persists indefinitely post-war.

**Fix:** Subscribe to the new `OnBattlefieldWarEnd` hook (added in [azerothcore-wotlk#25754](https://github.com/azerothcore/azerothcore-wotlk/pull/25754)). On war end, iterate the module's own `_wgWarPlayers` tracking (still populated since only the core's `PlayersInWar` was cleared) and call `ClearFakePlayer` for each participant, then clear the sets. The existing `OnBattlefieldPlayerLeaveZone` catch-all remains as a safety net and becomes a no-op for this path.

**Requires:** [azerothcore-wotlk#25754](https://github.com/azerothcore/azerothcore-wotlk/pull/25754) — `OnBattlefieldWarEnd` core hook.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request.

**Claude Sonnet 4.6** (Claude Code) was used to diagnose the bug and author the fix.

## Issues Addressed:
- Closes 

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Apply this PR together with [azerothcore-wotlk#25754](https://github.com/azerothcore/azerothcore-wotlk/pull/25754)
2. Enter Wintergrasp with characters from both factions; accept the war invitation so at least one is cross-faction assigned (appears as opposite race/faction)
3. End the war (timer expiry, relic capture, or `.bf stop`)
4. Confirm the cross-faction player **immediately** reverts to their real race and faction while still in the WG zone — no relog or zone exit required
5. Verify party interactions (buff, target visibility) are restored correctly

## Known Issues and TODO List:

- [ ]