### PR TITLE
fix(WG): Grant quest credit for non-lieutenant WG kills in CFBG

### DIFF
--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -210,6 +210,11 @@ private:
     uint32 timeCheck = 10000;
 };
 
+// WG constants duplicated here to avoid pulling in BattlefieldWG.h
+static constexpr uint32 WG_SPELL_LIEUTENANT            = 55629;
+static constexpr uint32 WG_NPC_QUEST_PVP_KILL_ALLIANCE = 31086;
+static constexpr uint32 WG_NPC_QUEST_PVP_KILL_HORDE    = 39019;
+
 class CFBG_Battlefield : public BattlefieldScript
 {
 public:
@@ -217,7 +222,8 @@ public:
         BATTLEFIELDHOOK_ON_PLAYER_JOIN_WAR,
         BATTLEFIELDHOOK_ON_PLAYER_LEAVE_WAR,
         BATTLEFIELDHOOK_ON_PLAYER_LEAVE_ZONE,
-        BATTLEFIELDHOOK_ON_WAR_END
+        BATTLEFIELDHOOK_ON_WAR_END,
+        BATTLEFIELDHOOK_ON_PLAYER_KILL
     }) {}
 
     void OnBattlefieldPlayerJoinWar(Battlefield* bf, Player* player) override
@@ -280,6 +286,32 @@ public:
         // player's real race/faction.
         if (sCFBG->IsPlayerFake(player))
             sCFBG->ClearFakePlayer(player);
+    }
+
+    void OnBattlefieldPlayerKill(Battlefield* bf, Player* killer, Player* victim) override
+    {
+        if (!sCFBG->IsEnableSystem() || !sCFBG->IsEnableWGSystem())
+            return;
+
+        if (bf->GetTypeId() != BATTLEFIELD_WG)
+            return;
+
+        // The core already grants credit when the victim has SPELL_LIEUTENANT (55629).
+        // This hook covers the remaining kills so that quest credit is not gated on
+        // victim rank, which would silently fail in short or low-population sessions.
+        if (victim->HasAura(WG_SPELL_LIEUTENANT))
+            return;
+
+        TeamId killerTeam = killer->GetTeamId();
+        uint32 creditNpc  = (killerTeam == TEAM_HORDE) ? WG_NPC_QUEST_PVP_KILL_ALLIANCE
+                                                        : WG_NPC_QUEST_PVP_KILL_HORDE;
+
+        for (ObjectGuid const& guid : bf->GetPlayersInWarSet(killerTeam))
+        {
+            Player* ally = ObjectAccessor::FindPlayer(guid);
+            if (ally && ally->GetDistance2d(killer) < 40.0f)
+                ally->KilledMonsterCredit(creditNpc);
+        }
     }
 
     void OnBattlefieldWarEnd(Battlefield* bf, bool /*endByTimer*/) override


### PR DESCRIPTION
## Changes Proposed:

In CFBG Wintergrasp, "No Mercy for the Merciless" / "Slay Them All" quest credit was silently lost whenever the victim had not yet earned `SPELL_LIEUTENANT` (which requires 10 WG kills in the current session). In short or low-population sessions nobody ever reaches that rank, so the quests effectively never progress.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### Implementation

Uses the new `OnBattlefieldPlayerKill` hook (added in the companion core PR) to grant `KilledMonsterCredit` to all nearby war-teammates of the killer for every player kill, bypassing the lieutenant gate. Double-credit on lieutenant kills is avoided by returning early when the victim already has `SPELL_LIEUTENANT` — the core's existing loop handles those.

Credit NPC selection mirrors the core logic and uses `killer->GetTeamId()`, which correctly reflects the CFBG-assigned fake team, so the right NPC (31086 for Alliance kills, 39019 for Horde kills) is always chosen.

**Depends on**: https://github.com/azerothcore/azerothcore-wotlk/pull/25871

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Sonnet 4.6 was used to implement this change.

## Issues Addressed:

- Closes N/A

## SOURCE:

The changes have been validated through:
- [ ] Live research
- [ ] Sniffs
- [ ] Video evidence, knowledge databases or other public sources
- [ ] Cherry-pick

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing.

1. Apply the companion core PR first.
2. Enable `CFBG.Battlefield.Enable = 1` in the CFBG config.
3. Enter Wintergrasp with a crossfaction group (Horde assigned to Alliance WG team, or vice versa).
4. Pick up "No Mercy for the Merciless" (Alliance) or "Slay Them All" (Horde) from the WG commander.
5. Kill an enemy player who does **not** have a WG rank aura yet.
6. Confirm the quest counter advances.
7. Kill an enemy player who **does** have `SPELL_LIEUTENANT` and confirm the counter advances exactly once (no double-credit).

## Known Issues and TODO List:

- [ ]
- [ ]