### PR TITLE
fix(WG): FFA quest credit for crossfaction WG kills

### DIFF
--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -296,21 +296,35 @@ public:
         if (bf->GetTypeId() != BATTLEFIELD_WG)
             return;
 
-        // The core already grants credit when the victim has SPELL_LIEUTENANT (55629).
-        // This hook covers the remaining kills so that quest credit is not gated on
-        // victim rank, which would silently fail in short or low-population sessions.
-        if (victim->HasAura(WG_SPELL_LIEUTENANT))
-            return;
-
+        // FFA quest credit: both PvP-kill credit NPCs are granted to every war
+        // player in range so that flipped players advance whichever quest they
+        // actually hold, regardless of the killer's assigned team. Granting a
+        // credit NPC for a quest the player does not have is a no-op.
+        //
+        // Core (BattlefieldWG.cpp) already grants `coreCredit` to killer-team
+        // players in range when the victim has SPELL_LIEUTENANT. We avoid
+        // double-crediting that case by giving coreCredit only to opposite-team
+        // players, and otherCredit to everyone.
         TeamId killerTeam = killer->GetTeamId();
-        uint32 creditNpc  = (killerTeam == TEAM_HORDE) ? WG_NPC_QUEST_PVP_KILL_ALLIANCE
+        uint32 coreCredit  = (killerTeam == TEAM_HORDE) ? WG_NPC_QUEST_PVP_KILL_ALLIANCE
                                                         : WG_NPC_QUEST_PVP_KILL_HORDE;
+        uint32 otherCredit = (killerTeam == TEAM_HORDE) ? WG_NPC_QUEST_PVP_KILL_HORDE
+                                                        : WG_NPC_QUEST_PVP_KILL_ALLIANCE;
+        bool coreAlreadyGaveCredit = victim->HasAura(WG_SPELL_LIEUTENANT);
 
-        for (ObjectGuid const& guid : bf->GetPlayersInWarSet(killerTeam))
+        for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
         {
-            Player* ally = ObjectAccessor::FindPlayer(guid);
-            if (ally && ally->GetDistance2d(killer) < 40.0f)
-                ally->KilledMonsterCredit(creditNpc);
+            bool isKillerTeam = (TeamId(team) == killerTeam);
+            for (ObjectGuid const& guid : bf->GetPlayersInWarSet(TeamId(team)))
+            {
+                Player* p = ObjectAccessor::FindPlayer(guid);
+                if (!p || p->GetDistance2d(killer) >= 40.0f)
+                    continue;
+
+                if (!(coreAlreadyGaveCredit && isKillerTeam))
+                    p->KilledMonsterCredit(coreCredit);
+                p->KilledMonsterCredit(otherCredit);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

When a player is flipped to the opposite team by CFBG in Wintergrasp, the WG PvP-kill quests (`Slay Them All` 13180/13178 for Horde, `No Mercy for the Merciless` 13179/13177 for Alliance) didn't advance.

A real-Horde player flipped to Alliance still holds the **Horde** quest (needs credit NPC `31086`), but the existing hook only granted one credit NPC chosen by the killer's *assigned* team — so killing Horde as flipped-Alliance gave `39019` (Alliance-side credit) and the original quest stayed at 0.

## Fix

`OnBattlefieldPlayerKill` now iterates **both** teams' war players within 40y of the killer and grants **both** PvP-kill credit NPCs to each. Granting credit for a quest the player doesn't hold is a no-op, so this is safe for non-flipped players.

The core's lieutenant-victim path (`BattlefieldWG.cpp`) still grants one credit ID to killer-team players. To avoid double-credit on that specific quest tick, the hook skips the core-side credit for killer-team players when the victim has `SPELL_LIEUTENANT` (55629).

### Credit matrix per kill

| Victim | Player team vs killer | coreCredit | otherCredit |
|---|---|---|---|
| Lieutenant | Killer's team | core gives | hook gives |
| Lieutenant | Opposite team | hook gives | hook gives |
| Non-lieutenant | Killer's team | hook gives | hook gives |
| Non-lieutenant | Opposite team | hook gives | hook gives |

Every war player in range gets both credit IDs exactly once per kill, regardless of faction flips.

## Test plan

- [ ] Real-Horde player with `Slay Them All` (13180) gets flipped to Alliance, kills a Horde player → kill counter advances.
- [ ] Real-Alliance player with `No Mercy for the Merciless` (13179) gets flipped to Horde, kills an Alliance player → kill counter advances.
- [ ] Non-flipped players continue to advance their own quests normally.
- [ ] Lieutenant kills do not grant double credit on a single quest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)