### PR TITLE
feat: add .cfbg debug command for inspecting player CFBG state

### DIFF
--- a/data/sql/db-world/cfbg_commands.sql
+++ b/data/sql/db-world/cfbg_commands.sql
@@ -1,4 +1,5 @@
-DELETE FROM `command` WHERE `name` IN ('cfbg', 'cfbg race');
+DELETE FROM `command` WHERE `name` IN ('cfbg', 'cfbg race', 'cfbg debug');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('cfbg', 0, 'Crossfaction battleground module commands.'),
-('cfbg race', 0, 'Morphs your character to the selected race once you join a battleground.\nBy default, the following races are available: human, dwarf, gnome, draenei ("broken ones"), orc, bloodelf, troll, tauren.');
+('cfbg race', 0, 'Morphs your character to the selected race once you join a battleground.\nBy default, the following races are available: human, dwarf, gnome, draenei ("broken ones"), orc, bloodelf, troll, tauren.'),
+('cfbg debug', 1, 'Syntax: .cfbg debug [$playername]\nDumps the target/self player''s CFBG state: enable flags, fake/native/forget flags, native vs current race/team/display, preferred race setting, and the stored FakePlayer record when faked. Console requires $playername.');

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -157,6 +157,7 @@ public:
 
     bool SendRealNameQuery(Player* player);
     bool IsPlayerFake(Player* player);
+    FakePlayer const* GetFakePlayer(Player* player) const;
     bool ShouldForgetInListPlayers(Player* player);
     bool IsPlayingNative(Player* player);
 
@@ -199,7 +200,6 @@ private:
     RandomSkinInfo GetRandomRaceMorph(TeamId team, uint8 playerClass, uint8 gender);
 
     uint32 GetMorphFromRace(uint8 race, uint8 gender);
-    FakePlayer const* GetFakePlayer(Player* player) const;
 
     void InviteSameCountGroups(GroupsList& groups, BattlegroundQueue* bgQueue, uint32 maxAli, uint32 maxHorde, Battleground* bg = nullptr);
     TeamId InviteGroupToBG(GroupQueueInfo* gInfo, BattlegroundQueue* bgQueue, uint32 maxAli, uint32 maxHorde, Battleground* bg = nullptr);

--- a/src/cs_cfbg.cpp
+++ b/src/cs_cfbg.cpp
@@ -22,7 +22,8 @@ public:
     {
         static ChatCommandTable cfbgCommands =
         {
-            { "race", HandleCFBGChooseRace, SEC_PLAYER, Console::No },
+            { "race",  HandleCFBGChooseRace, SEC_PLAYER,        Console::No  },
+            { "debug", HandleCFBGDebug,      SEC_MODERATOR,     Console::Yes },
         };
 
         static ChatCommandTable commandTable =
@@ -93,6 +94,67 @@ public:
         else
         {
             handler->PSendSysMessage("CFBG selected race set to {}", raceInput);
+        }
+
+        return true;
+    }
+
+    static char const* TeamIdName(TeamId t)
+    {
+        switch (t)
+        {
+            case TEAM_ALLIANCE: return "Alliance";
+            case TEAM_HORDE:    return "Horde";
+            default:            return "Neutral";
+        }
+    }
+
+    static bool HandleCFBGDebug(ChatHandler* handler, Optional<PlayerIdentifier> player)
+    {
+        if (!player)
+            player = PlayerIdentifier::FromTargetOrSelf(handler);
+
+        if (!player || !player->IsConnected())
+        {
+            handler->SendErrorMessage(LANG_PLAYER_NOT_FOUND);
+            return false;
+        }
+
+        Player* target = player->GetConnectedPlayer();
+
+        bool const isFake     = sCFBG->IsPlayerFake(target);
+        bool const native     = sCFBG->IsPlayingNative(target);
+        bool const forgetBG   = sCFBG->ShouldForgetBGPlayers(target);
+        bool const forgetList = sCFBG->ShouldForgetInListPlayers(target);
+
+        uint8 const preferredRace = target->GetPlayerSetting("mod-cfbg", SETTING_CFBG_RACE).value;
+
+        handler->PSendSysMessage("CFBG debug: {} [GUID: {}]",
+            target->GetName(), target->GetGUID().ToString());
+        handler->PSendSysMessage("  System enabled: {}  WG enabled: {}",
+            sCFBG->IsEnableSystem() ? "yes" : "no",
+            sCFBG->IsEnableWGSystem() ? "yes" : "no");
+        handler->PSendSysMessage("  Faked: {}  PlayingNative: {}",
+            isFake ? "yes" : "no", native ? "yes" : "no");
+        handler->PSendSysMessage("  ForgetBGPlayers: {}  ForgetInListPlayers: {}",
+            forgetBG ? "yes" : "no", forgetList ? "yes" : "no");
+        handler->PSendSysMessage("  Class: {}  Gender: {}",
+            uint32(target->getClass()), uint32(target->getGender()));
+        handler->PSendSysMessage("  Native : race={}  team={}",
+            uint32(target->getRace(true)), TeamIdName(target->GetTeamId(true)));
+        handler->PSendSysMessage("  Current: race={}  team={}  display={}/{} (current/native)",
+            uint32(target->getRace()), TeamIdName(target->GetTeamId()),
+            target->GetDisplayId(), target->GetNativeDisplayId());
+        handler->PSendSysMessage("  PreferredRace setting: {}", uint32(preferredRace));
+
+        if (FakePlayer const* fake = sCFBG->GetFakePlayer(target))
+        {
+            handler->SendSysMessage("  Fake record:");
+            handler->PSendSysMessage("    Fake race={}  morph={}  team={}",
+                uint32(fake->FakeRace), fake->FakeMorph, TeamIdName(fake->FakeTeamID));
+            handler->PSendSysMessage("    Real race={}  morph={}  nativeMorph={}  team={}",
+                uint32(fake->RealRace), fake->RealMorph, fake->RealNativeMorph,
+                TeamIdName(fake->RealTeamID));
         }
 
         return true;


### PR DESCRIPTION
## Summary
- Adds `.cfbg debug [$playername]`, a console-accessible command (GM 1+) that dumps a player's CFBG state.
- Defaults to target/self in-game; console requires a player name.
- Output: enable flags (system/WG), `Faked`/`PlayingNative`/`ForgetBGPlayers`/`ForgetInListPlayers`, class/gender, native vs current race+team+display IDs, the `SETTING_CFBG_RACE` preference, and the stored `FakePlayer` record (fake + real race/morph/team) when the player is currently faked.
- Promotes `CFBG::GetFakePlayer` from `private` to `public` so the command can read the fake record.
- Registers `cfbg debug` in `cfbg_commands.sql` (security `1`, help text), and includes it in the matching `DELETE` for idempotency.

## Test plan
- [ ] Build with the module enabled.
- [ ] Apply `cfbg_commands.sql` against `acore_world`.
- [ ] In-game as GM ≥ 1: `.cfbg debug` (self), `.cfbg debug` with another player targeted, `.cfbg debug PlayerName`.
- [ ] From console: `cfbg debug PlayerName` (online) and confirm offline name returns `Player not found`.
- [ ] Verify the `Fake record` block appears only while inside a BG / WG war (i.e. while the player is in `_fakePlayerStore`).
- [ ] Confirm SEC_PLAYER cannot invoke `.cfbg debug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)