### PR TITLE
fix(BG): clear stale WG fake at BG entry to prevent team desync

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -351,6 +351,12 @@ void CFBG::ValidatePlayerForBG(Battleground* bg, Player* player)
     if (!_IsEnableSystem || !bg || bg->isArena() || !player)
         return;
 
+    // A WG fake survives the teleport into a BG: OnPlayerUpdateZone's
+    // InBattleground() guard blocks the deferred clear. Drop it so
+    // BalanceTeamsOnEntry and SetFakeRaceAndMorph run against BG state.
+    if (IsPlayerFake(player))
+        ClearFakePlayer(player);
+
     BalanceTeamsOnEntry(bg, player);
 
     TeamId teamId{ player->GetBgTeamId() };


### PR DESCRIPTION
## Summary
- A player faked for Wintergrasp who joins a BG retains the WG fake into the BG instance: `OnBattlefieldPlayerLeaveZone` stopped clearing it in #147, and the deferred `OnPlayerUpdateZone` clear is blocked by the `InBattleground()` guard added alongside #148 once the teleport lands on the BG map.
- The persistent fake short-circuits both `BalanceTeamsOnEntry` (its `IsPlayerFake` guard) and `SetFakeRaceAndMorph` (same guard), and can desync `bgTeamId` from `GetTeamId()`. The worst case: a real Alliance player queues for a BG before WG war pops, gets faked Horde mid-queue, and lands on the Alliance queue-side spawn with a Horde faction/visual — flag captures, faction checks, and graveyard assignment all disagree.
- Fix: clear any pre-existing fake at the top of `ValidatePlayerForBG` so the BG entry path re-evaluates against `bgTeamId`. The #147 timing concern doesn't apply here — `Battlefield::HandlePlayerLeaveZone` has already finished by the time `Battleground::AddPlayer` runs on the new map.

## Test plan
- [ ] Real Alliance player queues for a BG before WG war pops, gets WG-faked Horde mid-queue, accepts the BG invite — confirm they land on the queue-side as their real Alliance race with a consistent faction (no Horde-on-Alliance desync).
- [ ] WG-faked Horde player queues for a BG (so queue side = Horde), accepts the BG invite — confirm a fresh BG fake is applied (race randomized for the BG, `SETTING_CFBG_RACE` honored if set), `bgTeamId` matches `GetTeamId()`.
- [ ] Normal BG entry from outside WG still works (no double-fake, no missing fake).
- [ ] BG end / leave correctly restores real race / faction (no leftover fake from the entry-time clear).
- [ ] WG entry from outside (no BG involvement) still fakes and restores correctly — no regression on the WG-only path.
- [ ] `BalanceTeamsOnEntry` disabled (`= 0`): the fix still resolves the desync; player just doesn't get rebalanced (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)