### PR TITLE
refactor(WG): remove unused PrepareFakeTeamForBF/ApplyFakeVisualsForBF

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -553,60 +553,6 @@ void CFBG::SetFakeRaceAndMorphForBF(Player* player, TeamId assignedTeam)
     _fakePlayerStore.emplace(player, std::move(fakePlayerInfo));
 }
 
-void CFBG::PrepareFakeTeamForBF(Player* player, TeamId assignedTeam)
-{
-    if (!player || IsPlayerFake(player))
-        return;
-
-    TeamId realTeam = player->GetTeamId(true);
-    if (realTeam == assignedTeam)
-        return;
-
-    // Generate race/morph so the full FakePlayer record is ready for when
-    // ApplyFakeVisualsForBF fires later (on war accept).  We do NOT call
-    // setRace / SetDisplayId / SetNativeDisplayId here — only the faction
-    // (team) is changed so that every subsequent core bucket write uses the
-    // assigned team.
-    RandomSkinInfo skinInfo{ GetRandomRaceMorph(realTeam, player->getClass(), player->getGender()) };
-
-    uint8 selectedRace = player->GetPlayerSetting("mod-cfbg", SETTING_CFBG_RACE).value;
-
-    if (!RandomizeRaces() && selectedRace && IsRaceValidForFaction(realTeam, selectedRace))
-    {
-        skinInfo.first = selectedRace;
-        skinInfo.second = GetMorphFromRace(skinInfo.first, player->getGender());
-    }
-
-    FakePlayer fakePlayerInfo
-    {
-        skinInfo.first,
-        skinInfo.second,
-        assignedTeam,
-        player->getRace(true),
-        player->GetDisplayId(),
-        player->GetNativeDisplayId(),
-        realTeam
-    };
-
-    // Team change only — visuals are deferred to ApplyFakeVisualsForBF.
-    SetFactionForRace(player, fakePlayerInfo.FakeRace, fakePlayerInfo.FakeTeamID);
-
-    _fakePlayerStore.emplace(player, std::move(fakePlayerInfo));
-}
-
-void CFBG::ApplyFakeVisualsForBF(Player* player)
-{
-    FakePlayer const* fakeInfo = GetFakePlayer(player);
-    if (!fakeInfo)
-        return;
-
-    // Visual changes deferred from PrepareFakeTeamForBF: apply them now that
-    // the player has actually accepted the war invitation.
-    player->setRace(fakeInfo->FakeRace);
-    player->SetDisplayId(fakeInfo->FakeMorph);
-    player->SetNativeDisplayId(fakeInfo->FakeMorph);
-}
-
 void CFBG::SetFactionForRace(Player* player, uint8 Race, TeamId teamId)
 {
     if (!player)

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -164,8 +164,6 @@ public:
     void ValidatePlayerForBG(Battleground* bg, Player* player);
     void SetFakeRaceAndMorph(Player* player);
     void SetFakeRaceAndMorphForBF(Player* player, TeamId assignedTeam);
-    void PrepareFakeTeamForBF(Player* player, TeamId assignedTeam);
-    void ApplyFakeVisualsForBF(Player* player);
     void SetFactionForRace(Player* player, uint8 Race, TeamId teamId);
     void ClearFakePlayer(Player* player);
     void DoForgetPlayersInList(Player* player);


### PR DESCRIPTION
## Summary

- Removes `CFBG::PrepareFakeTeamForBF` and `CFBG::ApplyFakeVisualsForBF`, which were declared, defined, and never called anywhere in the module.
- The pair implemented a deferred "set faction first, apply visuals on war accept" flow for WG. The active war-join path (`OnBattlefieldPlayerJoinWar` in `CFBG_SC.cpp`) uses the single-shot `SetFakeRaceAndMorphForBF` instead, so the deferred pair is dead code.
- No behavior change; pure subtraction (56 lines).

## Test plan

- [ ] Build module under AzerothCore (`-DMODULES=static`) and confirm no unresolved symbols.
- [ ] Smoke check: enter a regular BG as cross-faction — fake morph applies as before.
- [ ] Smoke check: enter Wintergrasp during war as cross-faction — fake faction/morph applies on war accept (`SetFakeRaceAndMorphForBF` path), clears on war end / zone leave / logout-outside-war as before.
- [ ] `.cfbg debug` still reports `Faked` / `FakePlayer` struct values correctly.