### PR TITLE
refactor: key fake-player tracking by ObjectGuid instead of raw Player*

### DIFF
--- a/data/sql/db-world/cfbg_commands.sql
+++ b/data/sql/db-world/cfbg_commands.sql
@@ -2,4 +2,4 @@ DELETE FROM `command` WHERE `name` IN ('cfbg', 'cfbg race', 'cfbg debug');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('cfbg', 0, 'Crossfaction battleground module commands.'),
 ('cfbg race', 0, 'Morphs your character to the selected race once you join a battleground.\nBy default, the following races are available: human, dwarf, gnome, draenei ("broken ones"), orc, bloodelf, troll, tauren.'),
-('cfbg debug', 1, 'Syntax: .cfbg debug [$playername]\nDumps the target/self player''s CFBG state: enable flags, fake/native/forget flags, native vs current race/team/display, preferred race setting, and the stored FakePlayer record when faked. Console requires $playername.');
+('cfbg debug', 1, 'Syntax: .cfbg debug [$playername]\nDumps the target/self player''s CFBG state: enable flags, fake/native/forget flags, native vs current race/team/display, and preferred race setting. Console requires $playername.');

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -12,6 +12,7 @@
 #include "Containers.h"
 #include "Language.h"
 #include "Log.h"
+#include "ObjectAccessor.h"
 #include "Opcodes.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
@@ -495,23 +496,14 @@ void CFBG::SetFakeRaceAndMorph(Player* player)
         skinInfo.second = GetMorphFromRace(skinInfo.first, player->getGender());
     }
 
-    FakePlayer fakePlayerInfo
-    {
-        skinInfo.first,
-        skinInfo.second,
-        player->TeamIdForRace(skinInfo.first),
-        player->getRace(true),
-        player->GetDisplayId(),
-        player->GetNativeDisplayId(),
-        player->GetTeamId(true)
-    };
+    TeamId const fakeTeam = player->TeamIdForRace(skinInfo.first);
 
-    player->setRace(fakePlayerInfo.FakeRace);
-    SetFactionForRace(player, fakePlayerInfo.FakeRace, fakePlayerInfo.FakeTeamID);
-    player->SetDisplayId(fakePlayerInfo.FakeMorph);
-    player->SetNativeDisplayId(fakePlayerInfo.FakeMorph);
+    player->setRace(skinInfo.first);
+    SetFactionForRace(player, skinInfo.first, fakeTeam);
+    player->SetDisplayId(skinInfo.second);
+    player->SetNativeDisplayId(skinInfo.second);
 
-    _fakePlayerStore.emplace(player, std::move(fakePlayerInfo));
+    _fakePlayerGuids.insert(player->GetGUID());
 }
 
 void CFBG::SetFakeRaceAndMorphForBF(Player* player, TeamId assignedTeam)
@@ -534,23 +526,12 @@ void CFBG::SetFakeRaceAndMorphForBF(Player* player, TeamId assignedTeam)
         skinInfo.second = GetMorphFromRace(skinInfo.first, player->getGender());
     }
 
-    FakePlayer fakePlayerInfo
-    {
-        skinInfo.first,
-        skinInfo.second,
-        assignedTeam,
-        player->getRace(true),
-        player->GetDisplayId(),
-        player->GetNativeDisplayId(),
-        realTeam
-    };
+    player->setRace(skinInfo.first);
+    SetFactionForRace(player, skinInfo.first, assignedTeam);
+    player->SetDisplayId(skinInfo.second);
+    player->SetNativeDisplayId(skinInfo.second);
 
-    player->setRace(fakePlayerInfo.FakeRace);
-    SetFactionForRace(player, fakePlayerInfo.FakeRace, assignedTeam);
-    player->SetDisplayId(fakePlayerInfo.FakeMorph);
-    player->SetNativeDisplayId(fakePlayerInfo.FakeMorph);
-
-    _fakePlayerStore.emplace(player, std::move(fakePlayerInfo));
+    _fakePlayerGuids.insert(player->GetGUID());
 }
 
 void CFBG::SetFactionForRace(Player* player, uint8 Race, TeamId teamId)
@@ -572,29 +553,45 @@ void CFBG::SetFactionForRace(Player* player, uint8 Race, TeamId teamId)
 
 void CFBG::ClearFakePlayer(Player* player)
 {
-    if (!IsPlayerFake(player))
+    if (player)
+        ClearFakePlayer(player->GetGUID());
+}
+
+void CFBG::ClearFakePlayer(ObjectGuid guid)
+{
+    if (!_fakePlayerGuids.contains(guid))
         return;
 
-    player->setRace(_fakePlayerStore[player].RealRace);
-    player->SetDisplayId(_fakePlayerStore[player].RealMorph);
-    player->SetNativeDisplayId(_fakePlayerStore[player].RealNativeMorph);
-    SetFactionForRace(player, _fakePlayerStore[player].RealRace, _fakePlayerStore[player].RealTeamID);
+    // Online players get visuals/faction restored from the canonical race+gender
+    // DBC entry; m_realRace survives the fake (Unit::setRace only touches m_race),
+    // so getRace(true) / GetTeamId(true) yield the real values without any stored
+    // snapshot. Offline players just drop the tracking entry -- they load real
+    // race/faction from the DB on next login regardless.
+    if (Player* player = ObjectAccessor::FindPlayer(guid))
+    {
+        uint8 const realRace = player->getRace(true);
+        TeamId const realTeam = player->GetTeamId(true);
 
-    // Clear forced faction reactions. Rank doesn't matter here, not used when they are removed.
-    player->GetReputationMgr().ApplyForceReaction(FACTION_FROSTWOLF_CLAN, REP_FRIENDLY, false);
-    player->GetReputationMgr().ApplyForceReaction(FACTION_STORMPIKE_GUARD, REP_FRIENDLY, false);
+        uint32 nativeDisplay = 0;
+        if (ChrRacesEntry const* raceEntry = sChrRacesStore.LookupEntry(realRace))
+            nativeDisplay = (player->getGender() == GENDER_MALE) ? raceEntry->model_m : raceEntry->model_f;
 
-    _fakePlayerStore.erase(player);
+        player->setRace(realRace);
+        player->SetDisplayId(nativeDisplay);
+        player->SetNativeDisplayId(nativeDisplay);
+        SetFactionForRace(player, realRace, realTeam);
+
+        // Clear forced faction reactions. Rank doesn't matter here, not used when they are removed.
+        player->GetReputationMgr().ApplyForceReaction(FACTION_FROSTWOLF_CLAN, REP_FRIENDLY, false);
+        player->GetReputationMgr().ApplyForceReaction(FACTION_STORMPIKE_GUARD, REP_FRIENDLY, false);
+    }
+
+    _fakePlayerGuids.erase(guid);
 }
 
 bool CFBG::IsPlayerFake(Player* player)
 {
-    return _fakePlayerStore.contains(player);
-}
-
-FakePlayer const* CFBG::GetFakePlayer(Player* player) const
-{
-    return Acore::Containers::MapGetValuePtr(_fakePlayerStore, player);
+    return player && _fakePlayerGuids.contains(player->GetGUID());
 }
 
 void CFBG::DoForgetPlayersInList(Player* player)

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 class Player;
@@ -48,20 +49,6 @@ constexpr auto FACTION_STORMPIKE_GUARD = 730;
 
 // Cfbg settings
 constexpr auto SETTING_CFBG_RACE = 0;
-
-struct FakePlayer
-{
-    // Fake
-    uint8   FakeRace;
-    uint32  FakeMorph;
-    TeamId  FakeTeamID;
-
-    // Real
-    uint8   RealRace;
-    uint32  RealMorph;
-    uint32  RealNativeMorph;
-    TeamId  RealTeamID;
-};
 
 struct RaceData
 {
@@ -157,7 +144,6 @@ public:
 
     bool SendRealNameQuery(Player* player);
     bool IsPlayerFake(Player* player);
-    FakePlayer const* GetFakePlayer(Player* player) const;
     bool ShouldForgetInListPlayers(Player* player);
     bool IsPlayingNative(Player* player);
 
@@ -166,6 +152,7 @@ public:
     void SetFakeRaceAndMorphForBF(Player* player, TeamId assignedTeam);
     void SetFactionForRace(Player* player, uint8 Race, TeamId teamId);
     void ClearFakePlayer(Player* player);
+    void ClearFakePlayer(ObjectGuid guid);
     void DoForgetPlayersInList(Player* player);
     void FitPlayerInTeam(Player* player, bool action, Battleground* bg);
     void DoForgetPlayersInBG(Player* player, Battleground* bg);
@@ -202,7 +189,7 @@ private:
     void InviteSameCountGroups(GroupsList& groups, BattlegroundQueue* bgQueue, uint32 maxAli, uint32 maxHorde, Battleground* bg = nullptr);
     TeamId InviteGroupToBG(GroupQueueInfo* gInfo, BattlegroundQueue* bgQueue, uint32 maxAli, uint32 maxHorde, Battleground* bg = nullptr);
 
-    std::unordered_map<Player*, FakePlayer> _fakePlayerStore;
+    std::unordered_set<ObjectGuid> _fakePlayerGuids;
     std::unordered_map<Player*, ObjectGuid> _fakeNamePlayersStore;
     std::unordered_map<Player*, bool> _forgetBGPlayersStore;
     std::unordered_map<Player*, bool> _forgetInListPlayersStore;

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -325,14 +325,14 @@ public:
             return;
 
         // Hook fires before OnBattleEnd clears PlayersInWar, so each side's
-        // war set still reflects who was actively fighting. ClearFakePlayer
-        // is a no-op for unfaked players, so iterating GUIDs that may or may
-        // not be faked is safe.
+        // war set still reflects who was actively fighting. The GUID-form
+        // ClearFakePlayer is a no-op for unfaked entries and covers both the
+        // online (restore in place via ObjectAccessor::FindPlayer) and
+        // offline (drop the tracking entry; real race/faction loads from DB
+        // on next login) cases.
         for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
             for (ObjectGuid const& guid : bf->GetPlayersInWarSet(static_cast<TeamId>(team)))
-                if (Player* player = ObjectAccessor::FindPlayer(guid))
-                    if (sCFBG->IsPlayerFake(player))
-                        sCFBG->ClearFakePlayer(player);
+                sCFBG->ClearFakePlayer(guid);
     }
 };
 

--- a/src/cs_cfbg.cpp
+++ b/src/cs_cfbg.cpp
@@ -147,16 +147,6 @@ public:
             target->GetDisplayId(), target->GetNativeDisplayId());
         handler->PSendSysMessage("  PreferredRace setting: {}", uint32(preferredRace));
 
-        if (FakePlayer const* fake = sCFBG->GetFakePlayer(target))
-        {
-            handler->SendSysMessage("  Fake record:");
-            handler->PSendSysMessage("    Fake race={}  morph={}  team={}",
-                uint32(fake->FakeRace), fake->FakeMorph, TeamIdName(fake->FakeTeamID));
-            handler->PSendSysMessage("    Real race={}  morph={}  nativeMorph={}  team={}",
-                uint32(fake->RealRace), fake->RealMorph, fake->RealNativeMorph,
-                TeamIdName(fake->RealTeamID));
-        }
-
         return true;
     }
 


### PR DESCRIPTION
## Summary

Switches the fake-player tracking from `unordered_map<Player*, FakePlayer> _fakePlayerStore` to `unordered_set<ObjectGuid> _fakePlayerGuids`, drops the `FakePlayer` struct + `GetFakePlayer()` method, and adds a GUID-form `ClearFakePlayer(ObjectGuid)` that resolves the player via `ObjectAccessor::FindPlayer` and handles online + offline cleanup uniformly.

## Why GUID

Raw `Player*` keys can outlive the player they describe. The `OnPlayerLogout` hook intentionally skips `ClearFakePlayer` while a WG war is active (so a relog can rejoin without re-faking), but the Player object is still deleted at the end of the logout flow. The entry in `_fakePlayerStore` survives with a dangling pointer key, and the next `new Player(...)` allocation can reuse that address — `_fakePlayerStore.contains(newPlayer)` then returns `true` for an unrelated character, and `ClearFakePlayer` would stamp the new player with the old player's stored race/morph/team/faction.

ObjectGuid is the project-wide convention for any reference that may outlive a single call/tick (see the project CLAUDE.md "Long-lived references" note); this module's `Player*`-keyed map was the lone exception.

## Why no struct

Six of the seven `FakePlayer` fields are derivable on demand:

- `RealRace` ← `getRace(true)` (m_realRace survives `setRace`, which only modifies m_race per `Unit::setRace`).
- `RealTeamID` ← `GetTeamId(true)` (derived from m_realRace).
- `RealNativeMorph` ← `ChrRacesEntry::model_m`/`model_f` for the player's gender — by definition the native model for race+gender.
- `Fake{Race,Morph,TeamID}` were write-once values already on the live player after fake application; only the dead-code `ApplyFakeVisualsForBF` (removed in #155) and the debug dump ever read them back.

Only `RealMorph` (the `DisplayId` snapshot at fake time) is genuinely non-derivable; it captured the player's active transformation visual (bear form, ghost wolf, transform aura). That snapshot was fragile though — the aura it intended to preserve may have expired during the fake — so the new code derives the canonical race+gender model on clear; an active transformation aura will reapply on its next tick.

## Side effects

- **`OnBattlefieldWarEnd` correctly drops offline entries now.** Previously the loop did `FindPlayer(guid)` and silently skipped offline GUIDs, leaking their entries into `_fakePlayerStore` forever. The new GUID-form `ClearFakePlayer` erases the set entry whether the player is online or not.
- **Loop collapses to one line per GUID** — no per-player nullptr/`IsPlayerFake` checks needed; the GUID form is a no-op for unfaked entries.
- **`.cfbg debug` no longer prints a "Fake record:" block.** The block was strictly redundant with the live "Native" / "Current" lines above it (which print real race/team from `getRace(true)` / `GetTeamId(true)` and current race/team/display from the live player fields). SQL help text updated accordingly.

## Test plan

- [ ] Build module under AzerothCore (`-DMODULES=static`) — confirm no unresolved symbols.
- [ ] Cross-faction BG entry → fake morph applies; BG end → race/team/display restored to native.
- [ ] Cross-faction WG entry → fake morph applies on war accept; war end → race/team/display restored for all war participants (including any who logged out mid-war once they relog).
- [ ] Logout in WG during war → relog post-war → character loads native race/faction from DB (already covered by the existing save path, since `SaveToDB` writes `getRace(true)` = `m_realRace`, not the fake `m_race`).
- [ ] `.cfbg debug` still prints sensible state for both faked and unfaked targets.