### PR TITLE
feat(WG): lock players to their assigned team for the war

### DIFF
--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -23,6 +23,15 @@
 #                    for the duration of their stay in the zone.
 #       Default: 1
 #
+#   CFBG.Battlefield.TeamLock.Enable
+#       Description: Lock a player to the team they were first assigned for the
+#                    current Wintergrasp war. Prevents re-rolling their faction
+#                    by dropping out of the war and rejoining (also survives
+#                    leaving the zone and relogging). The lock is per-war and
+#                    resets when the war ends. Requires CFBG.Battlefield.Enable = 1.
+#       Default: 1 - (Enabled)
+#                0 - (Disabled)
+#
 #   CFBG.Include.Avg.Ilvl.Enable
 #       Description: Enable check average item level for bg
 #       Default: 0
@@ -80,6 +89,7 @@
 
 CFBG.Enable = 1
 CFBG.Battlefield.Enable = 1
+CFBG.Battlefield.TeamLock.Enable = 1
 CFBG.BalancedTeams = 1
 CFBG.BalancedTeams.Class.LowLevel = 0
 CFBG.BalancedTeams.Class.MinLevel = 10

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -151,6 +151,7 @@ void CFBG::LoadConfig()
         return;
 
     _IsEnableWGSystem = sConfigMgr->GetOption<bool>("CFBG.Battlefield.Enable", true);
+    _IsEnableWGTeamLock = sConfigMgr->GetOption<bool>("CFBG.Battlefield.TeamLock.Enable", true);
     _IsEnableAvgIlvl = sConfigMgr->GetOption<bool>("CFBG.Include.Avg.Ilvl.Enable", false);
     _IsEnableBalancedTeams = sConfigMgr->GetOption<bool>("CFBG.BalancedTeams", false);
     _IsEnableEvenTeams = sConfigMgr->GetOption<bool>("CFBG.EvenTeams.Enabled", false);
@@ -595,6 +596,25 @@ bool CFBG::IsPlayerFake(Player* player)
 FakePlayer const* CFBG::GetFakePlayer(Player* player) const
 {
     return Acore::Containers::MapGetValuePtr(_fakePlayerStore, player);
+}
+
+std::optional<TeamId> CFBG::GetWGWarAssignment(ObjectGuid guid) const
+{
+    auto const& itr = _wgWarAssignmentStore.find(guid);
+    if (itr == _wgWarAssignmentStore.end())
+        return std::nullopt;
+
+    return itr->second;
+}
+
+void CFBG::SetWGWarAssignment(ObjectGuid guid, TeamId team)
+{
+    _wgWarAssignmentStore[guid] = team;
+}
+
+void CFBG::ClearWGWarAssignments()
+{
+    _wgWarAssignmentStore.clear();
 }
 
 void CFBG::DoForgetPlayersInList(Player* player)

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -136,6 +136,7 @@ public:
 
     inline bool IsEnableSystem() const { return _IsEnableSystem; }
     inline bool IsEnableWGSystem() const { return _IsEnableWGSystem; }
+    inline bool IsEnableWGTeamLock() const { return _IsEnableWGTeamLock; }
     inline bool IsEnableAvgIlvl() const { return _IsEnableAvgIlvl; }
     inline bool IsEnableBalancedTeams() const { return _IsEnableBalancedTeams; }
     inline bool IsEnableBalanceClassLowLevel() const { return _IsEnableBalanceClassLowLevel; }
@@ -158,6 +159,13 @@ public:
     bool SendRealNameQuery(Player* player);
     bool IsPlayerFake(Player* player);
     FakePlayer const* GetFakePlayer(Player* player) const;
+
+    // Per-war WG team lock, GUID-keyed so it survives leaving the war/zone and
+    // relog. Cleared when the war ends.
+    std::optional<TeamId> GetWGWarAssignment(ObjectGuid guid) const;
+    void SetWGWarAssignment(ObjectGuid guid, TeamId team);
+    void ClearWGWarAssignments();
+
     bool ShouldForgetInListPlayers(Player* player);
     bool IsPlayingNative(Player* player);
 
@@ -203,6 +211,7 @@ private:
     TeamId InviteGroupToBG(GroupQueueInfo* gInfo, BattlegroundQueue* bgQueue, uint32 maxAli, uint32 maxHorde, Battleground* bg = nullptr);
 
     std::unordered_map<Player*, FakePlayer> _fakePlayerStore;
+    std::unordered_map<ObjectGuid, TeamId> _wgWarAssignmentStore;
     std::unordered_map<Player*, ObjectGuid> _fakeNamePlayersStore;
     std::unordered_map<Player*, bool> _forgetBGPlayersStore;
     std::unordered_map<Player*, bool> _forgetInListPlayersStore;
@@ -213,6 +222,7 @@ private:
     // For config
     bool _IsEnableSystem;
     bool _IsEnableWGSystem;
+    bool _IsEnableWGTeamLock;
     bool _IsEnableAvgIlvl;
     bool _IsEnableBalancedTeams;
     bool _IsEnableBalanceClassLowLevel;

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -260,21 +260,35 @@ public:
         if (sCFBG->IsPlayerFake(player))
             return;
 
-        // Hook fires before core's PlayersInWar.insert, so the candidate is
-        // counted in neither side here. Reading the live core set drops the
-        // parallel bucket we used to maintain and removes the divergence path
-        // where AddOrSetPlayerToCorrectBfGroup rejects the join after the
-        // hook has already mutated module state.
-        uint32 allianceCount = static_cast<uint32>(bf->GetPlayersInWarSet(TEAM_ALLIANCE).size());
-        uint32 hordeCount    = static_cast<uint32>(bf->GetPlayersInWarSet(TEAM_HORDE).size());
-
         TeamId realTeam     = player->GetTeamId(true);
         TeamId assignedTeam = realTeam;
 
-        if (realTeam == TEAM_ALLIANCE && allianceCount > hordeCount)
-            assignedTeam = TEAM_HORDE;
-        else if (realTeam == TEAM_HORDE && hordeCount > allianceCount)
-            assignedTeam = TEAM_ALLIANCE;
+        // Reuse the team locked earlier this war so rejoining keeps the same
+        // side instead of re-rolling the balance.
+        std::optional<TeamId> locked;
+        if (sCFBG->IsEnableWGTeamLock())
+            locked = sCFBG->GetWGWarAssignment(player->GetGUID());
+
+        if (locked)
+            assignedTeam = *locked;
+        else
+        {
+            // Hook fires before core's PlayersInWar.insert, so the candidate is
+            // counted in neither side here. Reading the live core set drops the
+            // parallel bucket we used to maintain and removes the divergence path
+            // where AddOrSetPlayerToCorrectBfGroup rejects the join after the
+            // hook has already mutated module state.
+            uint32 allianceCount = static_cast<uint32>(bf->GetPlayersInWarSet(TEAM_ALLIANCE).size());
+            uint32 hordeCount    = static_cast<uint32>(bf->GetPlayersInWarSet(TEAM_HORDE).size());
+
+            if (realTeam == TEAM_ALLIANCE && allianceCount > hordeCount)
+                assignedTeam = TEAM_HORDE;
+            else if (realTeam == TEAM_HORDE && hordeCount > allianceCount)
+                assignedTeam = TEAM_ALLIANCE;
+
+            if (sCFBG->IsEnableWGTeamLock())
+                sCFBG->SetWGWarAssignment(player->GetGUID(), assignedTeam);
+        }
 
         if (assignedTeam != realTeam)
             sCFBG->SetFakeRaceAndMorphForBF(player, assignedTeam);
@@ -333,6 +347,9 @@ public:
                 if (Player* player = ObjectAccessor::FindPlayer(guid))
                     if (sCFBG->IsPlayerFake(player))
                         sCFBG->ClearFakePlayer(player);
+
+        // Lock is per-war: drop assignments so the next war re-balances.
+        sCFBG->ClearWGWarAssignments();
     }
 };
 


### PR DESCRIPTION
## Changes Proposed

Locks a Wintergrasp cross-faction player to the team they were first assigned for the duration of a war.

Previously, players could re-roll their faction by dropping out of the war and rejoining. Team assignment was recomputed on every `OnBattlefieldPlayerJoinWar`, and the only guard skipped already-faked players. That left two gaps:

- **Native-team assignees were never recorded**, so they were re-balanced on every join and could be flipped to the opposite faction.
- **Faked players reset once they left the zone** (the fake is cleared in `OnPlayerUpdateZone`), so re-entering and re-queuing re-rolled them too.

### Fix

A GUID-keyed, per-war assignment store records each player's first WG team. On subsequent joins the stored team is reused instead of re-balancing, so the assignment survives:

- dropping out of the war and rejoining,
- leaving and re-entering the zone,
- relogging during the war.

The store is cleared when the war ends (in `OnBattlefieldWarEnd`), so the next war balances from scratch and stale entries can't accumulate. GUID keying (not `Player*`) keeps the lock valid across reconnects.

### Config

Gated behind a new option `CFBG.Battlefield.TeamLock.Enable` (default `1`, requires `CFBG.Battlefield.Enable = 1`). When disabled, every join re-balances exactly as before.

## Issues Addressed

Players being reassigned to a different team after leaving and rejoining a Wintergrasp war.

## Tests Performed

C++ codestyle (`apps/codestyle/codestyle-cpp.py`) passes. Not yet runtime-tested in-game.

## How to Test the Changes

1. Enable `CFBG.Enable`, `CFBG.Battlefield.Enable`, and `CFBG.Battlefield.TeamLock.Enable`.
2. Join a Wintergrasp war and note the assigned faction.
3. Leave the war (and/or the zone, and/or relog) and rejoin the same war — the assigned faction should be unchanged.
4. After the war ends, a new war should balance assignments freshly.
