### PR TITLE
fix(WG): re-apply crossfaction fake on resurrect

### DIFF
--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -32,6 +32,14 @@
 #       Default: 1 - (Enabled)
 #                0 - (Disabled)
 #
+#   CFBG.Battlefield.ReapplyOnResurrect.Enable
+#       Description: Re-apply a cross-faction player's assigned race/faction/morph
+#                    when they resurrect inside Wintergrasp, so the ghost->alive
+#                    transition does not revert them to their native faction.
+#                    Requires CFBG.Battlefield.Enable = 1.
+#       Default: 1 - (Enabled)
+#                0 - (Disabled)
+#
 #   CFBG.Include.Avg.Ilvl.Enable
 #       Description: Enable check average item level for bg
 #       Default: 0
@@ -90,6 +98,7 @@
 CFBG.Enable = 1
 CFBG.Battlefield.Enable = 1
 CFBG.Battlefield.TeamLock.Enable = 1
+CFBG.Battlefield.ReapplyOnResurrect.Enable = 1
 CFBG.BalancedTeams = 1
 CFBG.BalancedTeams.Class.LowLevel = 0
 CFBG.BalancedTeams.Class.MinLevel = 10

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -152,6 +152,7 @@ void CFBG::LoadConfig()
 
     _IsEnableWGSystem = sConfigMgr->GetOption<bool>("CFBG.Battlefield.Enable", true);
     _IsEnableWGTeamLock = sConfigMgr->GetOption<bool>("CFBG.Battlefield.TeamLock.Enable", true);
+    _IsEnableWGReapplyOnResurrect = sConfigMgr->GetOption<bool>("CFBG.Battlefield.ReapplyOnResurrect.Enable", true);
     _IsEnableAvgIlvl = sConfigMgr->GetOption<bool>("CFBG.Include.Avg.Ilvl.Enable", false);
     _IsEnableBalancedTeams = sConfigMgr->GetOption<bool>("CFBG.BalancedTeams", false);
     _IsEnableEvenTeams = sConfigMgr->GetOption<bool>("CFBG.EvenTeams.Enabled", false);

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -594,6 +594,20 @@ void CFBG::ClearFakePlayer(Player* player)
     _fakePlayerStore.erase(player);
 }
 
+void CFBG::ReapplyFakePlayer(Player* player)
+{
+    FakePlayer const* info = GetFakePlayer(player);
+    if (!info)
+        return;
+
+    // Re-push the stored fake values after a resurrect so the assigned faction
+    // and morph survive the ghost->alive transition.
+    player->setRace(info->FakeRace);
+    SetFactionForRace(player, info->FakeRace, info->FakeTeamID);
+    player->SetDisplayId(info->FakeMorph);
+    player->SetNativeDisplayId(info->FakeMorph);
+}
+
 bool CFBG::IsPlayerFake(Player* player)
 {
     return _fakePlayerStore.contains(player);

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -137,6 +137,7 @@ public:
     inline bool IsEnableSystem() const { return _IsEnableSystem; }
     inline bool IsEnableWGSystem() const { return _IsEnableWGSystem; }
     inline bool IsEnableWGTeamLock() const { return _IsEnableWGTeamLock; }
+    inline bool IsEnableWGReapplyOnResurrect() const { return _IsEnableWGReapplyOnResurrect; }
     inline bool IsEnableAvgIlvl() const { return _IsEnableAvgIlvl; }
     inline bool IsEnableBalancedTeams() const { return _IsEnableBalancedTeams; }
     inline bool IsEnableBalanceClassLowLevel() const { return _IsEnableBalanceClassLowLevel; }
@@ -224,6 +225,7 @@ private:
     bool _IsEnableSystem;
     bool _IsEnableWGSystem;
     bool _IsEnableWGTeamLock;
+    bool _IsEnableWGReapplyOnResurrect;
     bool _IsEnableAvgIlvl;
     bool _IsEnableBalancedTeams;
     bool _IsEnableBalanceClassLowLevel;

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -174,6 +174,7 @@ public:
     void SetFakeRaceAndMorphForBF(Player* player, TeamId assignedTeam);
     void SetFactionForRace(Player* player, uint8 Race, TeamId teamId);
     void ClearFakePlayer(Player* player);
+    void ReapplyFakePlayer(Player* player);
     void DoForgetPlayersInList(Player* player);
     void FitPlayerInTeam(Player* player, bool action, Battleground* bg);
     void DoForgetPlayersInBG(Player* player, Battleground* bg);

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -108,7 +108,8 @@ public:
         PLAYERHOOK_CAN_JOIN_IN_BATTLEGROUND_QUEUE,
         PLAYERHOOK_ON_BEFORE_UPDATE,
         PLAYERHOOK_ON_BEFORE_SEND_CHAT_MESSAGE,
-        PLAYERHOOK_ON_REPUTATION_CHANGE
+        PLAYERHOOK_ON_REPUTATION_CHANGE,
+        PLAYERHOOK_ON_PLAYER_RESURRECT
     }) { }
 
     void OnPlayerLogin(Player* player) override
@@ -213,6 +214,23 @@ public:
 
         // to gm lang
         lang = LANG_UNIVERSAL;
+    }
+
+    void OnPlayerResurrect(Player* player, float /*restorePercent*/, bool& /*applySickness*/) override
+    {
+        if (!sCFBG->IsEnableSystem() || !sCFBG->IsEnableWGSystem())
+            return;
+
+        if (!sCFBG->IsPlayerFake(player))
+            return;
+
+        // Only re-apply for WG fakes. Battleground fakes are owned by the BG
+        // hooks and must not be touched here.
+        Battlefield* bf = sBattlefieldMgr->GetBattlefieldToZoneId(player->GetZoneId());
+        if (!bf || bf->GetTypeId() != BATTLEFIELD_WG)
+            return;
+
+        sCFBG->ReapplyFakePlayer(player);
     }
 
     bool OnPlayerReputationChange(Player* player, uint32 factionID, int32& standing, bool /*incremental*/) override

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -218,7 +218,7 @@ public:
 
     void OnPlayerResurrect(Player* player, float /*restorePercent*/, bool& /*applySickness*/) override
     {
-        if (!sCFBG->IsEnableSystem() || !sCFBG->IsEnableWGSystem())
+        if (!sCFBG->IsEnableSystem() || !sCFBG->IsEnableWGSystem() || !sCFBG->IsEnableWGReapplyOnResurrect())
             return;
 
         if (!sCFBG->IsPlayerFake(player))


### PR DESCRIPTION
## What

Re-applies a crossfaction Wintergrasp player's fake faction and morph when they resurrect, so they don't revert to their native race/faction after the ghost→alive transition.

## Why

A crossfaction WG player assigned to the opposite team is morphed via `setRace` / `SetDisplayId` / `SetFaction` (stored in `_fakePlayerStore`). The stored entry survives death, but the resurrection transition can leave the player showing their native race/faction. This re-pushes the stored fake values on resurrect.

## How

- New `CFBG::ReapplyFakePlayer(Player*)` re-applies the stored `FakePlayer` race/morph/faction (reuses the existing `GetFakePlayer` lookup and `SetFactionForRace`; idempotent).
- Hooked from a new `OnPlayerResurrect` override in `CFBG_Player`. `Player::ResurrectPlayer` fires this on every resurrect path (corpse run, spirit-healer, soulstone), so a single hook covers all cases.
- **Gated to Wintergrasp only**: enabled system + WG system + the player's zone resolving to a `BATTLEFIELD_WG` battlefield. Battleground fakes remain owned by the BG hooks and are untouched.

## Config

New option `CFBG.Battlefield.ReapplyOnResurrect.Enable` (default `1`) toggles the behaviour. Documented in `CFBG.conf.dist`, read in `LoadConfig`, and checked in the hook alongside the existing WG gates.

## Pets / summons

`SetFactionForRace` already loops `player->m_Controlled` and re-syncs faction, so any controlled unit alive at resurrect time is covered. Pets re-summoned after resurrection inherit the owner's (fake) faction automatically via core's summon path.

## Testing

C++ codestyle passes (`apps/codestyle/codestyle-cpp.py`).
