### PR TITLE
feat(WG): prioritize native faction, flip only the surplus at war start

### DIFF
--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -32,6 +32,16 @@
 #       Default: 1 - (Enabled)
 #                0 - (Disabled)
 #
+#   CFBG.Battlefield.NativePriority.Enable
+#       Description: When assigning teams for a Wintergrasp war, keep the minority
+#                    faction entirely on its native side and morph only the
+#                    majority's surplus to even the teams. The majority fills its
+#                    fair share native in invite-accept order, so the players moved
+#                    are the last to commit. Disable to fall back to the per-join
+#                    greedy balance. Requires CFBG.Battlefield.Enable = 1.
+#       Default: 1 - (Enabled)
+#                0 - (Disabled, greedy per-join balance)
+#
 #   CFBG.Battlefield.ReapplyOnResurrect.Enable
 #       Description: Re-apply a cross-faction player's assigned race/faction/morph
 #                    when they resurrect inside Wintergrasp, so the ghost->alive
@@ -100,6 +110,7 @@
 CFBG.Enable = 1
 CFBG.Battlefield.Enable = 1
 CFBG.Battlefield.TeamLock.Enable = 1
+CFBG.Battlefield.NativePriority.Enable = 1
 CFBG.Battlefield.ReapplyOnResurrect.Enable = 1
 CFBG.BalancedTeams = 1
 CFBG.BalancedTeams.Class.LowLevel = 0

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -151,6 +151,7 @@ void CFBG::LoadConfig()
 
     _IsEnableWGSystem = sConfigMgr->GetOption<bool>("CFBG.Battlefield.Enable", true);
     _IsEnableWGTeamLock = sConfigMgr->GetOption<bool>("CFBG.Battlefield.TeamLock.Enable", true);
+    _IsEnableWGNativePriority = sConfigMgr->GetOption<bool>("CFBG.Battlefield.NativePriority.Enable", true);
     _IsEnableWGReapplyOnResurrect = sConfigMgr->GetOption<bool>("CFBG.Battlefield.ReapplyOnResurrect.Enable", true);
     _IsEnableAvgIlvl = sConfigMgr->GetOption<bool>("CFBG.Include.Avg.Ilvl.Enable", false);
     _IsEnableBalancedTeams = sConfigMgr->GetOption<bool>("CFBG.BalancedTeams", false);
@@ -635,6 +636,37 @@ void CFBG::SetWGWarAssignment(ObjectGuid guid, TeamId team)
 void CFBG::ClearWGWarAssignments()
 {
     _wgWarAssignmentStore.clear();
+    _wgCensusValid = false;
+    _wgMajorityNativeKept = 0;
+}
+
+TeamId CFBG::ResolveWGWarTeam(Player* player, uint32 nativeAllianceInvited, uint32 nativeHordeInvited)
+{
+    // Capture the native split once: at the first join PlayersInWar is empty
+    // and nobody is faked, so the invited counts are the true native census.
+    if (!_wgCensusValid)
+    {
+        _wgMajorityTeam = (nativeAllianceInvited >= nativeHordeInvited) ? TEAM_ALLIANCE : TEAM_HORDE;
+        _wgMajorityFairShare = (nativeAllianceInvited + nativeHordeInvited) / 2;
+        _wgMajorityNativeKept = 0;
+        _wgCensusValid = true;
+    }
+
+    TeamId realTeam = player->GetTeamId(true);
+
+    // Minority stays native.
+    if (realTeam != _wgMajorityTeam)
+        return realTeam;
+
+    // Majority keeps its fair share native in accept order; the rest (latest
+    // to commit) flip.
+    if (_wgMajorityNativeKept < _wgMajorityFairShare)
+    {
+        ++_wgMajorityNativeKept;
+        return realTeam;
+    }
+
+    return (_wgMajorityTeam == TEAM_ALLIANCE) ? TEAM_HORDE : TEAM_ALLIANCE;
 }
 
 void CFBG::DoForgetPlayersInList(Player* player)

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -137,6 +137,7 @@ public:
     inline bool IsEnableSystem() const { return _IsEnableSystem; }
     inline bool IsEnableWGSystem() const { return _IsEnableWGSystem; }
     inline bool IsEnableWGTeamLock() const { return _IsEnableWGTeamLock; }
+    inline bool IsEnableWGNativePriority() const { return _IsEnableWGNativePriority; }
     inline bool IsEnableWGReapplyOnResurrect() const { return _IsEnableWGReapplyOnResurrect; }
     inline bool IsEnableAvgIlvl() const { return _IsEnableAvgIlvl; }
     inline bool IsEnableBalancedTeams() const { return _IsEnableBalancedTeams; }
@@ -166,6 +167,11 @@ public:
     std::optional<TeamId> GetWGWarAssignment(ObjectGuid guid) const;
     void SetWGWarAssignment(ObjectGuid guid, TeamId team);
     void ClearWGWarAssignments();
+
+    // Native-priority WG balancing: keep the minority native, flip only the
+    // majority's surplus (latest accepters). Census captured on the first call
+    // of a war, reset in ClearWGWarAssignments.
+    TeamId ResolveWGWarTeam(Player* player, uint32 nativeAllianceInvited, uint32 nativeHordeInvited);
 
     bool ShouldForgetInListPlayers(Player* player);
     bool IsPlayingNative(Player* player);
@@ -214,6 +220,12 @@ private:
 
     std::unordered_map<Player*, FakePlayer> _fakePlayerStore;
     std::unordered_map<ObjectGuid, TeamId> _wgWarAssignmentStore;
+
+    // Per-war native census for ResolveWGWarTeam, reset in ClearWGWarAssignments.
+    bool   _wgCensusValid        = false;
+    TeamId _wgMajorityTeam       = TEAM_ALLIANCE;
+    uint32 _wgMajorityFairShare  = 0;
+    uint32 _wgMajorityNativeKept = 0;
     std::unordered_map<Player*, ObjectGuid> _fakeNamePlayersStore;
     std::unordered_map<Player*, bool> _forgetBGPlayersStore;
     std::unordered_map<Player*, bool> _forgetInListPlayersStore;
@@ -225,6 +237,7 @@ private:
     bool _IsEnableSystem;
     bool _IsEnableWGSystem;
     bool _IsEnableWGTeamLock;
+    bool _IsEnableWGNativePriority;
     bool _IsEnableWGReapplyOnResurrect;
     bool _IsEnableAvgIlvl;
     bool _IsEnableBalancedTeams;

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -289,13 +289,22 @@ public:
 
         if (locked)
             assignedTeam = *locked;
+        else if (sCFBG->IsEnableWGNativePriority())
+        {
+            // Invited maps still hold the full native war population here:
+            // core erases each accepter from InvitedPlayers only after this hook.
+            uint32 allianceInvited = static_cast<uint32>(bf->GetInvitedPlayersMap(TEAM_ALLIANCE).size());
+            uint32 hordeInvited    = static_cast<uint32>(bf->GetInvitedPlayersMap(TEAM_HORDE).size());
+
+            assignedTeam = sCFBG->ResolveWGWarTeam(player, allianceInvited, hordeInvited);
+
+            if (sCFBG->IsEnableWGTeamLock())
+                sCFBG->SetWGWarAssignment(player->GetGUID(), assignedTeam);
+        }
         else
         {
-            // Hook fires before core's PlayersInWar.insert, so the candidate is
-            // counted in neither side here. Reading the live core set drops the
-            // parallel bucket we used to maintain and removes the divergence path
-            // where AddOrSetPlayerToCorrectBfGroup rejects the join after the
-            // hook has already mutated module state.
+            // Greedy fallback: candidate is in neither set yet (hook fires
+            // before PlayersInWar.insert), so balance off the live core counts.
             uint32 allianceCount = static_cast<uint32>(bf->GetPlayersInWarSet(TEAM_ALLIANCE).size());
             uint32 hordeCount    = static_cast<uint32>(bf->GetPlayersInWarSet(TEAM_HORDE).size());
 


### PR DESCRIPTION
## Summary

Changes Wintergrasp cross-faction team assignment to **prioritize each player's native faction** and morph only the surplus needed to even the teams, instead of the previous greedy per-join balance.

The greedy logic decided each player's side from the live in-war counts *at accept time*, before the final population was known. A minority-faction player who happened to accept the war invite early — when their side momentarily led — could be morphed unnecessarily, and with team-lock that wrong assignment stuck for the whole war.

## How it works

On the **first** join of a war, the native split is snapshotted from `Battlefield::GetInvitedPlayersMap` (valid at that point: `PlayersInWar` is empty and nobody is faked yet, since core erases each accepter from `InvitedPlayers` only *after* the join hook). Then per join:

- **Minority faction** → always stays native.
- **Majority faction** → keeps its fair share (`floor(total / 2)`) native in accept order; everyone past that — the latest to commit — flips to the other side.

Example: 30 Alliance / 10 Horde queue → all 10 Horde stay Horde, 20 Alliance stay Alliance, the last 10 Alliance accepters are faked to Horde → **20 v 20** with the minimum number of faction changes. The old logic could also flip Horde players depending on accept timing.

It composes with the existing per-war team-lock (lock is checked first, so relogs stay stable) and resets each war via `ClearWGWarAssignments()`.

## Config

New `CFBG.Battlefield.NativePriority.Enable` (default `1`). Set to `0` to fall back to the previous greedy balance.

## Notes

- Balance is computed from *invited* counts, so partial acceptance of the war invite can drift teams slightly off perfect 50/50 — still far fewer faction changes than greedy.
- "Latest to commit" is approximated by war-invite accept order; there is no real queue-entry timestamp in core (`PlayersInQueue` is an unordered set, `InvitedPlayers`' `time_t` is the invite-expiry set in a single tick).
- No core changes — entirely within the module, reusing the existing `OnBattlefieldPlayerJoinWar` hook and team-lock assignment map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)