### PR TITLE
fix: enforce assigned-team consistency in BGs

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -274,21 +274,18 @@ void CFBG::ValidatePlayerForBG(Battleground* bg, Player* player)
 
     BalanceTeamsOnEntry(bg, player);
 
-    TeamId teamId{ player->GetBgTeamId() };
+    TeamId const assigned = player->GetBgTeamId();
 
-    if (player->GetTeamId(true) == teamId)
-        return;
+    // Keep bgTeamId authoritative (also covers the TEAM_NEUTRAL bootstrap where GetBgTeamId() falls back to m_team)
+    player->GetBGData().bgTeamId = assigned;
 
-    BGData& bgdata = player->GetBGData();
+    EnforceBGTeamConsistency(player);
 
-    if (bgdata.bgTeamId != teamId)
-        bgdata.bgTeamId = teamId;
-
-    SetFakeRaceAndMorph(player);
-
-    if (bg->GetMapId() == MapAlteracValley)
+    // AV forced reactions apply only to a cross-faction (faked) player;
+    // a native player already holds the correct Frostwolf/Stormpike standings.
+    if (!IsPlayingNative(player) && bg->GetMapId() == MapAlteracValley)
     {
-        if (teamId == TEAM_HORDE)
+        if (assigned == TEAM_HORDE)
         {
             player->GetReputationMgr().ApplyForceReaction(FACTION_FROSTWOLF_CLAN, REP_FRIENDLY, true);
             player->GetReputationMgr().ApplyForceReaction(FACTION_STORMPIKE_GUARD, REP_HOSTILE, true);
@@ -301,6 +298,38 @@ void CFBG::ValidatePlayerForBG(Battleground* bg, Player* player)
 
         player->GetReputationMgr().SendForceReactions();
     }
+}
+
+void CFBG::EnforceBGTeamConsistency(Player* player)
+{
+    if (!player || !player->InBattleground())
+        return;
+
+    Battleground* bg = player->GetBattleground();
+    if (!bg || bg->isArena())
+        return;
+
+    TeamId const assigned = player->GetBgTeamId();
+
+    // Native: must not carry a fake.
+    if (player->GetTeamId(true) == assigned)
+    {
+        if (IsPlayerFake(player))
+            ClearFakePlayer(player);
+        return;
+    }
+
+    // Cross-faction: must be faked to `assigned`.
+    FakePlayer const* info = GetFakePlayer(player);
+    if (!info)
+        SetFakeRaceAndMorph(player);            // not faked yet -> apply
+    else if (info->FakeTeamID != assigned)
+    {
+        ClearFakePlayer(player);                // stale wrong-team fake -> redo
+        SetFakeRaceAndMorph(player);
+    }
+    else
+        ReapplyFakePlayer(player);              // correct side -> re-push reset values
 }
 
 void CFBG::BalanceTeamsOnEntry(Battleground* bg, Player* player)

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -160,6 +160,9 @@ public:
     bool IsPlayingNative(Player* player);
 
     void ValidatePlayerForBG(Battleground* bg, Player* player);
+    // Forces race/faction/m_team/fake-store into agreement with the player's
+    // assigned BG team (GetBgTeamId()); idempotent and self-correcting.
+    void EnforceBGTeamConsistency(Player* player);
     void SetFakeRaceAndMorph(Player* player);
     void SetFakeRaceAndMorphForBF(Player* player, TeamId assignedTeam);
     void SetFactionForRace(Player* player, uint8 Race, TeamId teamId);

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -218,7 +218,18 @@ public:
 
     void OnPlayerResurrect(Player* player, float /*restorePercent*/, bool& /*applySickness*/) override
     {
-        if (!sCFBG->IsEnableSystem() || !sCFBG->IsEnableWGSystem() || !sCFBG->IsEnableWGReapplyOnResurrect())
+        if (!sCFBG->IsEnableSystem())
+            return;
+
+        // Battleground fakes are not re-pushed elsewhere on resurrect;
+        // re-assert assigned-team consistency after the ghost->alive transition.
+        if (player->InBattleground())
+        {
+            sCFBG->EnforceBGTeamConsistency(player);
+            return;
+        }
+
+        if (!sCFBG->IsEnableWGSystem() || !sCFBG->IsEnableWGReapplyOnResurrect())
             return;
 
         if (!sCFBG->IsPlayerFake(player))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team assignment consistency for players in cross-faction battlegrounds.
  * Fixed team state restoration when players are resurrected during battleground matches.
  * Enhanced faction-specific standing updates for Alterac Valley cross-faction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->