### PR TITLE
feat(WG): add CFBG.Battlefield.SkipClasses to keep classes native

### DIFF
--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -40,6 +40,16 @@
 #       Default: 1 - (Enabled)
 #                0 - (Disabled)
 #
+#   CFBG.Battlefield.SkipClasses
+#       Description: Comma-separated list of class IDs excluded from Wintergrasp
+#                    cross-faction selection. Players of these classes always keep
+#                    their native faction and are never morphed/reassigned.
+#                    Class IDs: 1 Warrior, 2 Paladin, 3 Hunter, 4 Rogue, 5 Priest,
+#                    6 Death Knight, 7 Shaman, 8 Mage, 9 Warlock, 11 Druid.
+#                    Requires CFBG.Battlefield.Enable = 1.
+#       Example: "2,7" - (Paladins and Shamans stay native)
+#       Default: "" - (no class skipped)
+#
 #   CFBG.Include.Avg.Ilvl.Enable
 #       Description: Enable check average item level for bg
 #       Default: 0
@@ -101,6 +111,7 @@ CFBG.Enable = 1
 CFBG.Battlefield.Enable = 1
 CFBG.Battlefield.TeamLock.Enable = 1
 CFBG.Battlefield.ReapplyOnResurrect.Enable = 1
+CFBG.Battlefield.SkipClasses = ""
 CFBG.BalancedTeams = 1
 CFBG.BalancedTeams.Class.LowLevel = 0
 CFBG.BalancedTeams.Class.MinLevel = 10

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -14,6 +14,8 @@
 #include "Opcodes.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"
+#include "StringConvert.h"
+#include "Tokenize.h"
 #include "GameTime.h"
 #include "Player.h"
 #include "WorldSessionMgr.h"
@@ -152,6 +154,14 @@ void CFBG::LoadConfig()
     _IsEnableWGSystem = sConfigMgr->GetOption<bool>("CFBG.Battlefield.Enable", true);
     _IsEnableWGTeamLock = sConfigMgr->GetOption<bool>("CFBG.Battlefield.TeamLock.Enable", true);
     _IsEnableWGReapplyOnResurrect = sConfigMgr->GetOption<bool>("CFBG.Battlefield.ReapplyOnResurrect.Enable", true);
+
+    _wgSkipClasses.clear();
+    for (auto const& token : Acore::Tokenize(sConfigMgr->GetOption<std::string>("CFBG.Battlefield.SkipClasses", ""), ',', false))
+    {
+        if (Optional<uint8> playerClass = Acore::StringTo<uint8>(token))
+            _wgSkipClasses.insert(*playerClass);
+    }
+
     _IsEnableAvgIlvl = sConfigMgr->GetOption<bool>("CFBG.Include.Avg.Ilvl.Enable", false);
     _IsEnableBalancedTeams = sConfigMgr->GetOption<bool>("CFBG.BalancedTeams", false);
     _IsEnableEvenTeams = sConfigMgr->GetOption<bool>("CFBG.EvenTeams.Enabled", false);

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 class Player;
@@ -138,6 +139,7 @@ public:
     inline bool IsEnableWGSystem() const { return _IsEnableWGSystem; }
     inline bool IsEnableWGTeamLock() const { return _IsEnableWGTeamLock; }
     inline bool IsEnableWGReapplyOnResurrect() const { return _IsEnableWGReapplyOnResurrect; }
+    inline bool IsWGSkipClass(uint8 playerClass) const { return _wgSkipClasses.count(playerClass) > 0; }
     inline bool IsEnableAvgIlvl() const { return _IsEnableAvgIlvl; }
     inline bool IsEnableBalancedTeams() const { return _IsEnableBalancedTeams; }
     inline bool IsEnableBalanceClassLowLevel() const { return _IsEnableBalanceClassLowLevel; }
@@ -226,6 +228,7 @@ private:
     bool _IsEnableWGSystem;
     bool _IsEnableWGTeamLock;
     bool _IsEnableWGReapplyOnResurrect;
+    std::unordered_set<uint8> _wgSkipClasses;
     bool _IsEnableAvgIlvl;
     bool _IsEnableBalancedTeams;
     bool _IsEnableBalanceClassLowLevel;

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -278,6 +278,9 @@ public:
         if (sCFBG->IsPlayerFake(player))
             return;
 
+        if (sCFBG->IsWGSkipClass(player->getClass()))
+            return;
+
         TeamId realTeam     = player->GetTeamId(true);
         TeamId assignedTeam = realTeam;
 


### PR DESCRIPTION
## What

Adds `CFBG.Battlefield.SkipClasses`, a comma-separated list of class IDs excluded from Wintergrasp cross-faction selection. Players of a listed class always keep their native faction and are never morphed or reassigned by CFBG.

## Why

Some classes are faction-flavor sensitive (e.g. a server may want Shamans/Paladins to stay on their lore faction in WG). This gives operators per-class control without disabling crossfaction WG entirely.

## How

- Parsed once in `LoadConfig` into an `unordered_set<uint8>` via `Acore::Tokenize` + `StringTo<uint8>`.
- `OnBattlefieldPlayerJoinWar` returns early for listed classes, so no team lock or fake race/morph is applied.
- Empty by default (no class skipped); affects Wintergrasp only, not regular battlegrounds.

Class IDs: 1 Warrior, 2 Paladin, 3 Hunter, 4 Rogue, 5 Priest, 6 Death Knight, 7 Shaman, 8 Mage, 9 Warlock, 11 Druid. Example: `CFBG.Battlefield.SkipClasses = "5,6,7"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration setting to exclude specific player classes from cross-faction morphing in Wintergrasp. Classes specified in this option will retain their native faction assignment instead of being morphed to the opposing faction. This feature requires the cross-faction battlefield system to be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->