### PR TITLE
fix(WG): bind SkipClasses config to a local before Tokenize

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -102,7 +102,8 @@ void CFBG::LoadConfig()
     _IsEnableWGReapplyOnResurrect = sConfigMgr->GetOption<bool>("CFBG.Battlefield.ReapplyOnResurrect.Enable", true);
 
     _wgSkipClasses.clear();
-    for (auto const& token : Acore::Tokenize(sConfigMgr->GetOption<std::string>("CFBG.Battlefield.SkipClasses", ""), ',', false))
+    std::string const skipClasses = sConfigMgr->GetOption<std::string>("CFBG.Battlefield.SkipClasses", "");
+    for (auto const& token : Acore::Tokenize(skipClasses, ',', false))
     {
         if (Optional<uint8> playerClass = Acore::StringTo<uint8>(token))
             _wgSkipClasses.insert(*playerClass);


### PR DESCRIPTION
## Summary

Follow-up build fix for #169 (`CFBG.Battlefield.SkipClasses`).

`LoadConfig` passes the temporary `std::string` returned by `GetOption` directly into `Acore::Tokenize`. Since `Tokenize` returns `std::string_view`s that point into its argument, its rvalue overloads are deleted, so this fails to compile against a core that has the deleted overloads:

```
fatal error: call to deleted function 'Tokenize'
    for (auto const& token : Acore::Tokenize(sConfigMgr->GetOption<std::string>("CFBG.Battlefield.SkipClasses", ""), ',', false))
```

Fix: store the option in a named local first, so the views stay valid for the duration of the loop.

## Testing

- Compiles clean with the fix applied.
- No behaviour change: the parsed set and default (empty) are identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

No user-facing changes in this release. Internal code maintenance and optimization have been applied to improve code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->