### PR TITLE
Load with the new configuration

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -90,38 +90,45 @@ CFBG* CFBG::instance()
     return &instance;
 }
 
-void CFBG::LoadConfig()
+void CFBG::LoadWGSkipClasses(std::string skipClasses)
 {
-    _IsEnableSystem = sConfigMgr->GetOption<bool>("CFBG.Enable", false);
-    if (!_IsEnableSystem)
-        return;
-
-    _IsEnableWGSystem = sConfigMgr->GetOption<bool>("CFBG.Battlefield.Enable", true);
-    _IsEnableWGTeamLock = sConfigMgr->GetOption<bool>("CFBG.Battlefield.TeamLock.Enable", true);
-    _IsEnableWGNativePriority = sConfigMgr->GetOption<bool>("CFBG.Battlefield.NativePriority.Enable", true);
-    _IsEnableWGReapplyOnResurrect = sConfigMgr->GetOption<bool>("CFBG.Battlefield.ReapplyOnResurrect.Enable", true);
-
     _wgSkipClasses.clear();
-    std::string const skipClasses = sConfigMgr->GetOption<std::string>("CFBG.Battlefield.SkipClasses", "");
     for (auto const& token : Acore::Tokenize(skipClasses, ',', false))
-    {
         if (Optional<uint8> playerClass = Acore::StringTo<uint8>(token))
             _wgSkipClasses.insert(*playerClass);
-    }
+}
 
-    _IsEnableAvgIlvl = sConfigMgr->GetOption<bool>("CFBG.Include.Avg.Ilvl.Enable", false);
-    _IsEnableBalancedTeams = sConfigMgr->GetOption<bool>("CFBG.BalancedTeams", false);
-    _IsEnableEvenTeams = sConfigMgr->GetOption<bool>("CFBG.EvenTeams.Enabled", false);
-    _IsEnableBalanceClassLowLevel = sConfigMgr->GetOption<bool>("CFBG.BalancedTeams.Class.LowLevel", true);
-    _IsEnableResetCooldowns = sConfigMgr->GetOption<bool>("CFBG.ResetCooldowns", false);
-    _IsEnableBalanceTeamsOnEntry = sConfigMgr->GetOption<bool>("CFBG.BalanceTeamsOnEntry.Enabled", true);
-    _showPlayerName = sConfigMgr->GetOption<bool>("CFBG.Show.PlayerName", false);
-    _EvenTeamsMaxPlayersThreshold = sConfigMgr->GetOption<uint32>("CFBG.EvenTeams.MaxPlayersThreshold", 0);
-    _MaxPlayersCountInGroup = sConfigMgr->GetOption<uint32>("CFBG.Players.Count.In.Group", 3);
-    _balanceClassMinLevel = sConfigMgr->GetOption<uint8>("CFBG.BalancedTeams.Class.MinLevel", 10);
-    _balanceClassMaxLevel = sConfigMgr->GetOption<uint8>("CFBG.BalancedTeams.Class.MaxLevel", 19);
-    _balanceClassLevelDiff = sConfigMgr->GetOption<uint8>("CFBG.BalancedTeams.Class.LevelDiff", 2);
-    _randomizeRaces = sConfigMgr->GetOption<bool>("CFBG.RandomRaceSelection", true);
+void CFBG::LoadConfig(bool reload)
+{
+    _OutConfigData.Initialize(reload);
+}
+
+void CFBGOutConfigData::BuildConfigCache()
+{
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableSystem, "CFBG.Enable", false);
+    if (!sCFBG->IsEnableSystem())
+        return;
+
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableWGSystem, "CFBG.Battlefield.Enable", false);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableWGTeamLock, "CFBG.Battlefield.TeamLock.Enable", true);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableWGNativePriority, "CFBG.Battlefield.NativePriority.Enable", true);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableWGReapplyOnResurrect, "CFBG.Battlefield.ReapplyOnResurrect.Enable", true);
+
+    SetConfigValue<std::string>(CFBGOutConfig::_IsEnableWGSkipClasses, "CFBG.Battlefield.SkipClasses", "");
+    sCFBG->LoadWGSkipClasses(sCFBG->IsEnableWGSkipClasses());
+
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableBalancedTeams, "CFBG.BalancedTeams", false);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableBalanceClassLowLevel, "CFBG.BalancedTeams.Class.LowLevel", false);
+    SetConfigValue<uint32>(CFBGOutConfig::_balanceClassMinLevel, "CFBG.BalancedTeams.Class.MinLevel", 10);
+    SetConfigValue<uint32>(CFBGOutConfig::_balanceClassMaxLevel, "CFBG.BalancedTeams.Class.MaxLevel", 19);
+    SetConfigValue<uint32>(CFBGOutConfig::_balanceClassLevelDiff, "CFBG.BalancedTeams.Class.LevelDiff", 2);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableEvenTeams, "CFBG.EvenTeams.Enabled", false);
+    SetConfigValue<uint32>(CFBGOutConfig::_EvenTeamsMaxPlayersThreshold, "CFBG.EvenTeams.MaxPlayersThreshold", 0);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableAvgIlvl, "CFBG.Include.Avg.Ilvl.Enable", false);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableBalanceTeamsOnEntry, "CFBG.BalanceTeamsOnEntry.Enabled", true);
+    SetConfigValue<uint32>(CFBGOutConfig::_MaxPlayersCountInGroup, "CFBG.Players.Count.In.Group", 3);
+    SetConfigValue<bool>(CFBGOutConfig::_IsEnableResetCooldowns, "CFBG.ResetCooldowns", false);
+    SetConfigValue<bool>(CFBGOutConfig::_randomizeRaces, "CFBG.RandomRaceSelection", true);
 }
 
 uint32 CFBG::GetBGTeamAverageItemLevel(Battleground* bg, TeamId team)

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -152,24 +152,24 @@ public:
 
     void LoadConfig(bool reload);
 
-    inline bool IsEnableSystem() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableSystem); }
-    inline bool IsEnableWGSystem() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGSystem); }
-    inline bool IsEnableWGTeamLock() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGTeamLock); }
-    inline bool IsEnableWGNativePriority() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGNativePriority); }
-    inline bool IsEnableWGReapplyOnResurrect() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGReapplyOnResurrect); }
-    inline std::string IsEnableWGSkipClasses() const { return _OutConfigData.GetConfigValue<std::string>(CrossFactionBGOutConfig::_IsEnableWGSkipClasses); }
-    inline bool IsEnableBalancedTeams() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableBalancedTeams); }
-    inline bool IsEnableBalanceClassLowLevel() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableBalanceClassLowLevel); }
-    inline uint32 GetBalanceClassMinLevel() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_balanceClassMinLevel); }
-    inline uint32 GetBalanceClassMaxLevel() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_balanceClassMaxLevel); }
-    inline uint32 GetBalanceClassLevelDiff() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_balanceClassLevelDiff); }
-    inline bool IsEnableEvenTeams() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableEvenTeams); }
-    inline uint32 EvenTeamsMaxPlayersThreshold() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_EvenTeamsMaxPlayersThreshold); }
-    inline bool IsEnableAvgIlvl() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableAvgIlvl); }
-    inline bool IsEnableBalanceTeamsOnEntry() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableBalanceTeamsOnEntry); }
-    inline uint32 GetMaxPlayersCountInGroup() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_MaxPlayersCountInGroup); }
-    inline bool IsEnableResetCooldowns() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableResetCooldowns); }
-    inline bool RandomizeRaces() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_randomizeRaces); }
+    inline bool IsEnableSystem() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableSystem); }
+    inline bool IsEnableWGSystem() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableWGSystem); }
+    inline bool IsEnableWGTeamLock() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableWGTeamLock); }
+    inline bool IsEnableWGNativePriority() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableWGNativePriority); }
+    inline bool IsEnableWGReapplyOnResurrect() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableWGReapplyOnResurrect); }
+    inline std::string IsEnableWGSkipClasses() const { return _OutConfigData.GetConfigValue<std::string>(CFBGOutConfig::_IsEnableWGSkipClasses); }
+    inline bool IsEnableBalancedTeams() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableBalancedTeams); }
+    inline bool IsEnableBalanceClassLowLevel() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableBalanceClassLowLevel); }
+    inline uint32 GetBalanceClassMinLevel() const { return _OutConfigData.GetConfigValue<uint32>(CFBGOutConfig::_balanceClassMinLevel); }
+    inline uint32 GetBalanceClassMaxLevel() const { return _OutConfigData.GetConfigValue<uint32>(CFBGOutConfig::_balanceClassMaxLevel); }
+    inline uint32 GetBalanceClassLevelDiff() const { return _OutConfigData.GetConfigValue<uint32>(CFBGOutConfig::_balanceClassLevelDiff); }
+    inline bool IsEnableEvenTeams() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableEvenTeams); }
+    inline uint32 EvenTeamsMaxPlayersThreshold() const { return _OutConfigData.GetConfigValue<uint32>(CFBGOutConfig::_EvenTeamsMaxPlayersThreshold); }
+    inline bool IsEnableAvgIlvl() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableAvgIlvl); }
+    inline bool IsEnableBalanceTeamsOnEntry() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableBalanceTeamsOnEntry); }
+    inline uint32 GetMaxPlayersCountInGroup() const { return _OutConfigData.GetConfigValue<uint32>(CFBGOutConfig::_MaxPlayersCountInGroup); }
+    inline bool IsEnableResetCooldowns() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_IsEnableResetCooldowns); }
+    inline bool RandomizeRaces() const { return _OutConfigData.GetConfigValue<bool>(CFBGOutConfig::_randomizeRaces); }
 
     uint32 GetBGTeamAverageItemLevel(Battleground* bg, TeamId team);
     uint32 GetBGTeamSumPlayerLevel(Battleground* bg, TeamId team);

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -8,6 +8,8 @@
 #define _CFBG_H_
 
 #include "SharedDefines.h"
+#include "Config.h"
+#include "ConfigValueCache.h"
 #include "DBCEnums.h"
 #include "ObjectGuid.h"
 #include <array>
@@ -15,6 +17,37 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+enum class CFBGOutConfig
+{
+    _IsEnableSystem = 0,
+    _IsEnableWGSystem,
+    _IsEnableWGTeamLock,
+    _IsEnableWGNativePriority,
+    _IsEnableWGReapplyOnResurrect,
+    _IsEnableWGSkipClasses,
+    _IsEnableBalancedTeams,
+    _IsEnableBalanceClassLowLevel,
+    _balanceClassMinLevel,
+    _balanceClassMaxLevel,
+    _balanceClassLevelDiff,
+    _IsEnableEvenTeams,
+    _EvenTeamsMaxPlayersThreshold,
+    _IsEnableAvgIlvl,
+    _IsEnableBalanceTeamsOnEntry,
+    _MaxPlayersCountInGroup,
+    _IsEnableResetCooldowns,
+    _randomizeRaces,
+    NUM_CONFIGS
+};
+
+class CFBGOutConfigData : public ConfigValueCache<CFBGOutConfig>
+{
+public:
+    CFBGOutConfigData() : ConfigValueCache(CFBGOutConfig::NUM_CONFIGS) { }
+
+    void BuildConfigCache() override;
+};
 
 class Player;
 class Battlefield;
@@ -117,26 +150,26 @@ public:
 
     static CFBG* instance();
 
-    void LoadConfig();
+    void LoadConfig(bool reload);
 
-    inline bool IsEnableSystem() const { return _IsEnableSystem; }
-    inline bool IsEnableWGSystem() const { return _IsEnableWGSystem; }
-    inline bool IsEnableWGTeamLock() const { return _IsEnableWGTeamLock; }
-    inline bool IsEnableWGNativePriority() const { return _IsEnableWGNativePriority; }
-    inline bool IsEnableWGReapplyOnResurrect() const { return _IsEnableWGReapplyOnResurrect; }
-    inline bool IsWGSkipClass(uint8 playerClass) const { return _wgSkipClasses.count(playerClass) > 0; }
-    inline bool IsEnableAvgIlvl() const { return _IsEnableAvgIlvl; }
-    inline bool IsEnableBalancedTeams() const { return _IsEnableBalancedTeams; }
-    inline bool IsEnableBalanceClassLowLevel() const { return _IsEnableBalanceClassLowLevel; }
-    inline bool IsEnableEvenTeams() const { return _IsEnableEvenTeams; }
-    inline bool IsEnableResetCooldowns() const { return _IsEnableResetCooldowns; }
-    inline bool IsEnableBalanceTeamsOnEntry() const { return _IsEnableBalanceTeamsOnEntry; }
-    inline uint32 EvenTeamsMaxPlayersThreshold() const { return _EvenTeamsMaxPlayersThreshold; }
-    inline uint32 GetMaxPlayersCountInGroup() const { return _MaxPlayersCountInGroup; }
-    inline uint8 GetBalanceClassMinLevel() const { return _balanceClassMinLevel; }
-    inline uint8 GetBalanceClassMaxLevel() const { return _balanceClassMaxLevel; }
-    inline uint8 GetBalanceClassLevelDiff() const { return _balanceClassLevelDiff; }
-    inline bool RandomizeRaces() const { return _randomizeRaces; }
+    inline bool IsEnableSystem() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableSystem); }
+    inline bool IsEnableWGSystem() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGSystem); }
+    inline bool IsEnableWGTeamLock() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGTeamLock); }
+    inline bool IsEnableWGNativePriority() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGNativePriority); }
+    inline bool IsEnableWGReapplyOnResurrect() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableWGReapplyOnResurrect); }
+    inline std::string IsEnableWGSkipClasses() const { return _OutConfigData.GetConfigValue<std::string>(CrossFactionBGOutConfig::_IsEnableWGSkipClasses); }
+    inline bool IsEnableBalancedTeams() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableBalancedTeams); }
+    inline bool IsEnableBalanceClassLowLevel() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableBalanceClassLowLevel); }
+    inline uint32 GetBalanceClassMinLevel() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_balanceClassMinLevel); }
+    inline uint32 GetBalanceClassMaxLevel() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_balanceClassMaxLevel); }
+    inline uint32 GetBalanceClassLevelDiff() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_balanceClassLevelDiff); }
+    inline bool IsEnableEvenTeams() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableEvenTeams); }
+    inline uint32 EvenTeamsMaxPlayersThreshold() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_EvenTeamsMaxPlayersThreshold); }
+    inline bool IsEnableAvgIlvl() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableAvgIlvl); }
+    inline bool IsEnableBalanceTeamsOnEntry() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableBalanceTeamsOnEntry); }
+    inline uint32 GetMaxPlayersCountInGroup() const { return _OutConfigData.GetConfigValue<uint32>(CrossFactionBGOutConfig::_MaxPlayersCountInGroup); }
+    inline bool IsEnableResetCooldowns() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_IsEnableResetCooldowns); }
+    inline bool RandomizeRaces() const { return _OutConfigData.GetConfigValue<bool>(CrossFactionBGOutConfig::_randomizeRaces); }
 
     uint32 GetBGTeamAverageItemLevel(Battleground* bg, TeamId team);
     uint32 GetBGTeamSumPlayerLevel(Battleground* bg, TeamId team);
@@ -181,6 +214,9 @@ public:
 
     bool FillPlayersToCFBG(BattlegroundQueue* bgqueue, Battleground* bg, BattlegroundBracketId bracket_id);
     bool CheckCrossFactionMatch(BattlegroundQueue* bgqueue, BattlegroundBracketId bracket_id, uint32 minPlayers, uint32 maxPlayers);
+
+    void LoadWGSkipClasses(std::string skipClasses);
+    bool IsWGSkipClass(uint8 playerClass) const { return _wgSkipClasses.count(playerClass) > 0; }
 
     bool IsRaceValidForFaction(uint8 teamId, uint8 race);
     TeamId getTeamWithLowerClass(Battleground* bg, Classes c);
@@ -227,25 +263,8 @@ private:
     std::array<CFBGRaceInfo, 9> _raceInfo{};
 
     // For config
-    bool _IsEnableSystem;
-    bool _IsEnableWGSystem;
-    bool _IsEnableWGTeamLock;
-    bool _IsEnableWGNativePriority;
-    bool _IsEnableWGReapplyOnResurrect;
+    CFBGOutConfigData _OutConfigData;
     std::unordered_set<uint8> _wgSkipClasses;
-    bool _IsEnableAvgIlvl;
-    bool _IsEnableBalancedTeams;
-    bool _IsEnableBalanceClassLowLevel;
-    bool _IsEnableEvenTeams;
-    bool _IsEnableResetCooldowns;
-    bool _IsEnableBalanceTeamsOnEntry;
-    bool _showPlayerName;
-    bool _randomizeRaces;
-    uint32 _EvenTeamsMaxPlayersThreshold;
-    uint32 _MaxPlayersCountInGroup;
-    uint8 _balanceClassMinLevel;
-    uint8 _balanceClassMaxLevel;
-    uint8 _balanceClassLevelDiff;
 
     CFBG();
     ~CFBG() = default;

--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -401,9 +401,9 @@ public:
         WORLDHOOK_ON_AFTER_CONFIG_LOAD
     }) { }
 
-    void OnAfterConfigLoad(bool /*Reload*/) override
+    void OnAfterConfigLoad(bool Reload) override
     {
-        sCFBG->LoadConfig();
+        sCFBG->LoadConfig(Reload);
     }
 };
 


### PR DESCRIPTION
https://github.com/azerothcore/azerothcore-wotlk/pull/21647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Reworked battleground configuration loading to use a cached configuration layer for reliable access to feature flags and thresholds.
  * Added support for parsing and applying WG skip-class lists from the configured comma-separated values.
  * Updated configuration loading to accept an optional reload parameter.

* **Behavioral Updates**
  * Config reload behavior is now respected during post-configuration load handling.
  * Balance/team setting values are now read from the cached source (including updated balance level range outputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->