### PR TITLE
fix: allow .debug bg test starts when CFBG is enabled

### DIFF
--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "CFBG.h"
+#include "BattlegroundMgr.h"
 #include "BattlegroundQueue.h"
 #include "BattlegroundUtils.h"
 #include "Chat.h"
@@ -896,7 +897,13 @@ bool CFBG::CheckCrossFactionMatch(BattlegroundQueue* queue, BattlegroundBracketI
     if (!IsEnableSystem())
         return false;
 
-    SelectBalancedGroups(queue, bracket_id, nullptr, maxPlayers, IsEnableEvenTeams() ? 0 : 1);
+    bool isTesting = sBattlegroundMgr->isTesting();
+    SelectBalancedGroups(queue, bracket_id, nullptr, maxPlayers, isTesting ? maxPlayers : (IsEnableEvenTeams() ? 0 : 1));
+
+    // Mirror core CanStartMatch's testing arm: under .debug bg a single
+    // non-empty pool is enough to start (1v0), so skip the pool reset.
+    if (isTesting && (queue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount() || queue->m_SelectionPools[TEAM_HORDE].GetPlayerCount()))
+        return true;
 
     // Return when we're ready to start a BG, if we're in startup process
     if (queue->m_SelectionPools[TEAM_ALLIANCE].GetPlayerCount() >= minPlayers &&


### PR DESCRIPTION
- Closes #127

When CFBG is enabled, the core `.debug bg` command stops working: a GM who
toggles debug mode and queues a single character never gets an invite, because
`CheckCrossFactionMatch` fully replaces the core start checks and has no
handling for testing mode.

Two things go wrong there. With `CFBG.EvenTeams` enabled the balancing pass
drops a lone queuer outright, and even when the player survives selection the
start condition requires both teams to reach the minimum player count, so the
1v0/1v1 starts that core allows under `.debug bg` can never happen.

This change checks `sBattlegroundMgr->isTesting()` in `CheckCrossFactionMatch`
and, while testing is on, relaxes the balancing diff so a lone player is kept,
then accepts a single non-empty selection pool as a valid start. This mirrors
what core `BattlegroundQueue::CheckNormalMatch` does in testing mode. Both
changes are behind the `isTesting` check, so nothing changes on a live server
where `.debug bg` is off.

## How to test:
1. Set `CFBG.Enable = 1`, log in as GM, run `.debug bg`.
2. Queue a single character for any BG: the invite should pop on the next
   queue update and a 1v0 match starts.
3. Queue two characters of the same faction: a 1v1 match starts.
4. Turn `.debug bg` off and verify normal matchmaking is unchanged, including
   the EvenTeams behavior.

## AI Disclousure

Created with the help of Claude Code