### PR TITLE
fix: balancing tie fold

### DIFF
--- a/conf/CFBG.conf.dist
+++ b/conf/CFBG.conf.dist
@@ -61,7 +61,11 @@
 #       Default: "" - (no class skipped)
 #
 #   CFBG.Include.Avg.Ilvl.Enable
-#       Description: Enable check average item level for bg
+#       Description: Enable check average item level for bg.
+#                    Only takes effect when CFBG.BalancedTeams = 0. When
+#                    CFBG.BalancedTeams = 1 the average item level is always
+#                    consulted as an intrinsic tiebreaker of the balancing
+#                    cascade, regardless of this setting.
 #       Default: 0
 #
 #   CFBG.BalancedTeams

--- a/src/CFBG.cpp
+++ b/src/CFBG.cpp
@@ -224,11 +224,11 @@ TeamId CFBG::ResolveBalancedTeam(TeamBalanceContext const& ctx)
 
                 if (std::abs(avgLvlAlliance - avgLvlHorde) >= 0.5f)
                     team = avgLvlAlliance < avgLvlHorde ? TEAM_ALLIANCE : TEAM_HORDE;
-                else // it's balanced, so we should only check the ilvl
+                else if (ctx.avgIlvlA != ctx.avgIlvlH) // levels balanced, ilvl breaks the tie; an exact ilvl tie keeps the current pick
                     team = ctx.avgIlvlA < ctx.avgIlvlH ? TEAM_ALLIANCE : TEAM_HORDE;
             }
         }
-        else if (ctx.levelSumA == ctx.levelSumH)
+        else if (ctx.levelSumA == ctx.levelSumH && ctx.avgIlvlA != ctx.avgIlvlH)
         {
             team = ctx.avgIlvlA < ctx.avgIlvlH ? TEAM_ALLIANCE : TEAM_HORDE;
         }
@@ -780,12 +780,6 @@ void CFBG::SelectBalancedGroups(BattlegroundQueue* queue, BattlegroundBracketId 
 
         ctx.levelSumA = baseLevelSum[TEAM_ALLIANCE] + stagedLevelSum[TEAM_ALLIANCE];
         ctx.levelSumH = baseLevelSum[TEAM_HORDE] + stagedLevelSum[TEAM_HORDE];
-
-        // Fold the candidate's level sum into its projected side.
-        if (gInfo->teamId == TEAM_ALLIANCE)
-            ctx.levelSumA += cfInfo.SumPlayerLevel;
-        else
-            ctx.levelSumH += cfInfo.SumPlayerLevel;
 
         // ilvl metric: live BG average when reinforcing, staged sums at formation.
         ctx.avgIlvlA = bg ? GetBGTeamAverageItemLevel(bg, TEAM_ALLIANCE) : stagedIlvlSum[TEAM_ALLIANCE];

--- a/src/CFBG.h
+++ b/src/CFBG.h
@@ -99,7 +99,7 @@ struct TeamBalanceContext
 {
     int32  countA{ 0 };               // head counts, candidate EXCLUDED
     int32  countH{ 0 };
-    uint32 levelSumA{ 0 };            // candidate level ALREADY folded into its side
+    uint32 levelSumA{ 0 };            // level sums, candidate EXCLUDED (like the counts)
     uint32 levelSumH{ 0 };
     uint32 avgIlvlA{ 0 };            // per-team ilvl metric (bg avg OR queue sum)
     uint32 avgIlvlH{ 0 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team balancing decisions so tied teams now use average item level more consistently as a fallback.
  * Fixed balance calculations to better reflect the current candidate selection when comparing teams.
* **Documentation**
  * Clarified how the average item level setting behaves in different balancing modes, including when it is always used as a tie-breaker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->