### PR TITLE
fix(WG): credit Victory in Wintergrasp for crossfaction players

### DIFF
--- a/src/CFBG_SC.cpp
+++ b/src/CFBG_SC.cpp
@@ -298,6 +298,8 @@ public:
 static constexpr uint32 WG_SPELL_LIEUTENANT            = 55629;
 static constexpr uint32 WG_NPC_QUEST_PVP_KILL_ALLIANCE = 31086;
 static constexpr uint32 WG_NPC_QUEST_PVP_KILL_HORDE    = 39019;
+static constexpr uint32 WG_QUEST_VICTORY_ALLIANCE      = 13181;
+static constexpr uint32 WG_QUEST_VICTORY_HORDE         = 13183;
 
 class CFBG_Battlefield : public BattlefieldScript
 {
@@ -457,11 +459,32 @@ public:
         // war set still reflects who was actively fighting. ClearFakePlayer
         // is a no-op for unfaked players, so iterating GUIDs that may or may
         // not be faked is safe.
+
+        // "Victory in Wintergrasp": OnBattleEnd credits the winners with the
+        // quest of the defending (= winning) team only, which misses cross-
+        // faction players holding their native faction's copy. Grant the other
+        // one here -- AreaExploredOrEventHappens is a no-op on a quest the
+        // player does not hold, and core still grants its own right after.
+        uint32 const otherVictoryQuest = bf->GetDefenderTeam() == TEAM_ALLIANCE ? WG_QUEST_VICTORY_HORDE
+                                                                               : WG_QUEST_VICTORY_ALLIANCE;
+
         for (uint8 team = 0; team < PVP_TEAMS_COUNT; ++team)
+        {
+            bool const isWinner = static_cast<TeamId>(team) == bf->GetDefenderTeam();
+
             for (ObjectGuid const& guid : bf->GetPlayersInWarSet(static_cast<TeamId>(team)))
-                if (Player* player = ObjectAccessor::FindPlayer(guid))
-                    if (sCFBG->IsPlayerFake(player))
-                        sCFBG->ClearFakePlayer(player);
+            {
+                Player* player = ObjectAccessor::FindPlayer(guid);
+                if (!player)
+                    continue;
+
+                if (isWinner)
+                    player->AreaExploredOrEventHappens(otherVictoryQuest);
+
+                if (sCFBG->IsPlayerFake(player))
+                    sCFBG->ClearFakePlayer(player);
+            }
+        }
 
         // Lock is per-war: drop assignments so the next war re-balances.
         sCFBG->ClearWGWarAssignments();


### PR DESCRIPTION
## Problem

Core's `BattlefieldWG::OnBattleEnd` credits the winning side with a single quest id derived from the defending (winning) team:

```cpp
player->AreaExploredOrEventHappens(GetDefenderTeam() ? 13183 : 13181);
```

`13181` is the Alliance "Victory in Wintergrasp" (turned in to Tactical Officer Ahbramis), `13183` the Horde one (Tactical Officer Kilrath). A crossfaction player fighting as the opposite side still holds their own faction's copy, so that call does nothing for them and the turn-in never becomes available.

## Fix

Grant the other faction's victory quest to everyone in the winning war set from `OnBattlefieldWarEnd`, which runs before `OnBattleEnd` while `PlayersInWar` is still populated and `GetDefenderTeam()` already reflects the winner.

`AreaExploredOrEventHappens` is a no-op on a quest the player does not hold, so native players are unaffected and there is no double credit. This mirrors the existing PvP-kill credit handling in `OnBattlefieldPlayerKill`.

Only runs when both `CFBG.Enable` and the WG crossfaction system are on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wintergrasp victory quest credit for winning players, including cross-faction scenarios.

* **Bug Fixes**
  * Fixed missing victory quest event awards when Wintergrasp battles end.
  * Improved post-battle cleanup by clearing temporary players after rewards are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->